### PR TITLE
Refactor to use $timeout instead of $$phase

### DIFF
--- a/modules/directives/modal/src/modal.js
+++ b/modules/directives/modal/src/modal.js
@@ -1,5 +1,5 @@
 angular.module('ui.directives')
-.directive('uiModal', [function() {
+.directive('uiModal', ['$timeout', function() {
   return {
     require: 'ngModel',
     link: function(scope, elm, attrs, model) {
@@ -7,12 +7,14 @@ angular.module('ui.directives')
           elm.modal(value && 'show' || 'hide');
       });
       elm.on('show.ui', function() {
-        model.$setViewValue(true);
-        if (!scope.$$phase) scope.$apply();
+		$timeout(function() {
+    		 model.$setViewValue(true);
+    	});
       });
       elm.on('hide.ui', function() {
-        model.$setViewValue(false);
-        if (!scope.$$phase) scope.$apply();
+        $timeout(function() {
+        	model.$setViewValue(false);
+        });
       });
     }
   };

--- a/modules/directives/modal/test/modalSpec.js
+++ b/modules/directives/modal/test/modalSpec.js
@@ -2,18 +2,21 @@ describe('modal', function() {
   var elm, scope;
 
   beforeEach(module('ui.directives'));
-  beforeEach(inject(function($rootScope, $compile) {
+  
+  beforeEach(inject(function($injector, $rootScope, $compile) {
     scope = $rootScope;
+    $timeout = $injector.get('$timeout');
     elm = $compile(
       '<div class="modal hide" ui-modal ng-model="modalShown">'
     )($rootScope);
   }));
-
+  
   describe('model change', function() {
     it('should open modal', function() {
       scope.$apply(function() {
         scope.modalShown = true;
       });
+      $timeout.flush();
       expect(elm.hasClass('in')).toBe(true);
     });
 
@@ -21,6 +24,7 @@ describe('modal', function() {
       scope.$apply(function() {
         scope.modalShown = false;
       });
+      $timeout.flush();
       expect(elm.hasClass('in')).toBe(false);
     });
   });
@@ -28,11 +32,15 @@ describe('modal', function() {
   describe('open/close events', function() {
     it('should set model true when modal opens', function() {
       elm.modal('show');
+      expect(scope.modalShown).toBeUndefined();
+      $timeout.flush();
       expect(scope.modalShown).toBe(true);
     });
 
     it('should set model false when modal closes', function() {
       elm.modal('hide');
+      expect(scope.modalShown).toBeUndefined();
+      $timeout.flush();
       expect(scope.modalShown).toBe(false);
     });
   })


### PR DESCRIPTION
This uses angular external api over internal scope.$$phase. It was a bit painful to find secret
sauce for doing unit tests but it works. 
