### PR TITLE
ui-event & length filter changes

### DIFF
--- a/modules/directives/event/src/event.js
+++ b/modules/directives/event/src/event.js
@@ -6,12 +6,16 @@
  * 
  * @param ui-event {string|object literal} The event to bind to as a string or a hash of events with their callbacks
  */
-angular.module('ui.directives').directive('uiEvent', [function() {
+angular.module('ui.directives').directive('uiEvent', ['$parse',
+function($parse) {
 	return function(scope, elm, attrs) {
 		var events = scope.$eval(attrs.uiEvent);
-		angular.forEach(events, function(event, key){
-			elm.bind(key, function() {
-				scope.$apply(event);
+		angular.forEach(events, function(uiEvent, eventName){
+      var fn = $parse(uiEvent);
+			elm.bind(eventName, function(evt) {
+				scope.$apply(function() {
+          fn(scope, {$event: evt})
+        });
 			});
 		});
 	};

--- a/modules/directives/event/test/eventSpec.js
+++ b/modules/directives/event/test/eventSpec.js
@@ -1,0 +1,72 @@
+describe('uiEvent', function() {
+  var $scope, $rootScope, $compile
+
+  beforeEach(module('ui.directives'));
+  beforeEach(inject(function(_$rootScope_, _$compile_) {
+    $compile = _$compile_;
+    $rootScope = _$rootScope_;
+  }));
+
+  //helper for creating event elements
+  function eventElement(scope, eventObject) {
+    function uiEventAttrs() {
+      var str = '', first = true;
+      angular.forEach(eventObject, function(val, key) {
+        if (first) first = false;
+        else str += ', ';
+        str += "'"+key+"': '"+val+"'";
+      });
+      return '{'+str+'}';
+    };
+    return $compile('<span ui-event="'+uiEventAttrs()+'">')(scope);
+  };
+
+  describe('test', function() {
+    it('should work with dblclick event and assignment', function() {
+      $scope = $rootScope.$new();
+      var elm = eventElement($scope, {'dblclick': 'dbl=true'});
+      expect($scope.dbl).toBeUndefined();
+      elm.trigger('dblclick');
+      expect($scope.dbl).toBe(true);
+    });
+
+    it('should work with two events in one key a function', function() {
+      $scope = $rootScope.$new();
+      $scope.counter = 0;
+      $scope.myfn = function() {
+        $scope.counter++;
+      };
+      var elm = eventElement($scope, {'keyup mouseenter': 'myfn()'});
+      elm.trigger('keyup');
+      elm.trigger('mouseenter');
+      expect($scope.counter).toBe(2);
+    });
+
+    it('should work work with multiple entries', function() {
+      $scope = $rootScope.$new();
+      $scope.amount = 5;
+      var elm = eventElement($scope, {
+        'click': 'amount=amount*2',
+        'mouseenter': 'amount=amount*4',
+        'keyup': 'amount=amount*3', 
+      });
+      elm.trigger('click');
+      expect($scope.amount).toBe(10);
+      elm.trigger('mouseenter');
+      expect($scope.amount).toBe(40);
+      elm.trigger('keyup');
+      expect($scope.amount).toBe(120);
+    });
+
+    it('should allow passing of $event object', function() {
+      $scope = $rootScope.$new();
+      $scope.clicky = function(par1, $event, par2) {
+        expect($event).toBeTruthy();
+        expect(par1 + par2).toBe(3);
+      };
+      var elm = eventElement($scope, {'click': 'clicky(1, $event, 2)'});
+      $(elm).trigger('click');
+    });
+  });
+
+});

--- a/modules/filters/length/src/length.js
+++ b/modules/filters/length/src/length.js
@@ -1,9 +1,14 @@
 
 /**
- * Returns the length property of the filtered object
+ * Returns the length of the filtered object or array
  */
 angular.module('ui.filters').filter('length', function() {
-	return function(value) {
-		return value.length;
-	};
+  return function(value) {
+    var len = 0;
+    if (typeof value.length == 'undefined') {
+      for (key in value) len++;
+      return len;
+    }
+    return value.length;
+  };
 });

--- a/modules/filters/length/test/lengthSpec.js
+++ b/modules/filters/length/test/lengthSpec.js
@@ -1,0 +1,19 @@
+describe('length', function() {
+  var lengthFilter;
+
+  beforeEach(module('ui.filters'));
+  beforeEach(inject(function($filter) {
+    lengthFilter = $filter('length');
+  }));
+
+  it('should return length of an array', function() {
+    expect(lengthFilter([0,1,2])).toBe(3);
+    expect(lengthFilter([])).toBe(0);
+  });
+  it('should return length of an object', function() {
+    expect(lengthFilter({a:'b',b:'c',c:'d'})).toBe(3);
+  });
+  it('should return length of a string', function() {
+    expect('abcde'.length).toBe(5);
+  });
+})


### PR DESCRIPTION
Dunno how to do two seperate pull requests for each change.

**ui-event**: needed to be able to pass the $event object like the ng-event directives, so I added that and unit tests.  I was unsure how to actually programatically add a custom event object to a jquery event for the tests, so the tests for $event are lacking right now.  Can someone help with that?

**length filter**: added ability to get length of an object, and unit tests.

Look good to all?
