### PR TITLE
So this is intended to let someone pass MULTIPLE parameters

### DIFF
--- a/modules/directives/jq/src/jq.js
+++ b/modules/directives/jq/src/jq.js
@@ -29,12 +29,10 @@ angular.module('ui.directives').directive('uiJq', ['ui.config', function(uiConfi
 				if (attrs.uiOptions) {
 					evalOptions = scope.$eval('['+attrs.uiOptions+']');
 					if (angular.isObject(options) && angular.isObject(evalOptions[0])) {
-						angular.extend(options, evalOptions[0]);
-					} else {
-						options = evalOptions[0];
+						evalOptions[0] = angular.extend(options, evalOptions[0]);
 					}
 				}
-				elm[attrs.uiJq](options);
+				elm[attrs.uiJq].apply(elm, evalOptions);
 			}
 		}
 	};


### PR DESCRIPTION
In order to pass them to the jquery plugin, use ui-options.
Pass the options, comma-separated as you would a function.

Example: `<div ui-jq="accordion" ui-options="'option', optionName , [value]">`

This may be completely unnecessary since the function is only called upon init at this time. RFC
