### PR TITLE
Rewrote Select2

### DIFF
--- a/modules/directives/select2/src/select2.js
+++ b/modules/directives/select2/src/select2.js
@@ -2,16 +2,9 @@
 /**
  * Enhanced Select2 Dropmenus
  *
- * @concerns When the plugin loads, it injects an extra DIV into the DOM below itself. This disrupts the
- *   compiler, breaking everything below. Because of this, it must be initialized asynchronously (late).
- *   Since the ng:model and ng:options/ng:repeat can be populated by AJAX, they must be monitored in order
- *   to refresh the plugin so that it reflects the selected value
- * @AJAX Multiselect - For these, you must use an <input>. The values will NOT be in the form of an Array,
- *   but a comma-separated list. You must adjust the value as needed before using accordingly
- * @params [options] {object} The configuration options passed to $().select2(). Refer to the documentation
- *   - [watch] {string} an expression to monitor for changes. For use with ng:repeat populated via ajax
- *   - [ajax.initial] {function(url, values, multiple)} a callback function that returns the query string
- *   		to retrieve initial information about preselected/default values
+ * @AJAX Mode - When in this mode, your value will be an object (or array of objects) of the data used by Select2
+ * 		This change is so that you do not have to do an additional query yourself on top of Select2's own query
+ * @params [options] {object} The configuration options passed to $.fn.select2(). Refer to the documentation
  */
 angular.module('ui.directives').directive('uiSelect2', ['ui.config', '$http', function(uiConfig, $http){
 	var options = {};
@@ -20,85 +13,83 @@ angular.module('ui.directives').directive('uiSelect2', ['ui.config', '$http', fu
 	}
 	return {
 		require: '?ngModel',
-		link: function(scope, elm, attrs, controller) {
-		    // Indicates if the widget has been initialized atleast once or not. Please read default init above
-			var init = true, 
-				opts, // instance-specific options
-				prevVal = '',
-				loaded = false,
-				multiple = false;
-			
-			if(typeof attrs.multiple !== 'undefined'){
-			    multiple = true;
-			}
+		compile: function(tElm, tAttrs) {
+			var watch,
+			repeatOption,
+			isSelect = tElm.is('select'),
+			isMultiple = (tAttrs.multiple !== undefined);
 
-			opts = angular.extend({}, options, scope.$eval(attrs.uiSelect2));
-			
-			if (!elm.is('select') && opts.ajax) {
-				if(multiple){
-					opts.multiple = true;
+			// Enable watching of the options dataset if in use
+			if (tElm.is('select')) {
+				repeatOption = tElm.find('option[ng-repeat]');
+				if (repeatOption.length) {
+					watch = repeatOption.attr('ng-repeat').split(' ').pop();
 				}
-				// Set the view and model value and update the angular template manually for the ajax/multiple select2.
-				elm.bind("change", function(){
-					controller.$setViewValue(elm.val());
-					scope.$apply();
-				});
 			}
 
-			function initialize(newVal) {
-				setTimeout(function(){
-					if (newVal !== undefined) {
-						if (opts.ajax) {
-							if (newVal && !$.isEmptyObject(newVal)) {
-								if (init && opts.initial) {
-									var url = opts.initial(opts.ajax.url, newVal, opts.multiple);
-								    $http({ method: 'GET', url: url }).success(function(data, status, headers, config){
-										data = opts.ajax.results(data);
-										elm.select2('val', data.results || '');
-									});
-									init = false;
-								}
-							} else {
-							    elm.select2('val', '');
-							}
+			return function(scope, elm, attrs, controller) {
+				// instance-specific options
+				var opts = angular.extend({}, options, scope.$eval(attrs.uiSelect2));
+				
+				if (isSelect) {
+					// Use <select multiple> instead
+					delete opts.multiple;
+					delete opts.initSelection;
+				}
+
+				if (controller) {
+					// Watch the model for programmatic changes
+					controller.$render = function(value) {
+						if (isSelect) {
+							elm.select2('val', scope.$eval(attrs.ngModel));
 						} else {
-							elm.select2('val', newVal);
+							elm.select2('data', scope.$eval(attrs.ngModel));
+						}
+					};
+
+					// Watch the options dataset for changes
+					if (watch) {
+						scope.$watch(watch, function(newVal, oldVal, scope){
+							if (!newVal) return;
+							// Delayed so that the options have time to be rendered
+							setTimeout(function(){
+								elm.select2('val', controller.$viewValue);
+								// Refresh angular to remove the superfluous option
+								elm.trigger('change');
+							});
+						});
+					}
+
+					if (!isSelect) {
+						// Set the view and model value and update the angular template manually for the ajax/multiple select2.
+						elm.bind("change", function(){
+							scope.$apply(function(){
+								controller.$setViewValue(elm.select2('data'));
+							});
+						});
+
+						if (opts.initSelection) {
+							var initSelection = opts.initSelection;
+							opts.initSelection = function(element, callback) {
+								initSelection(element, function(value){
+									controller.$setViewValue(value);
+									callback(value);
+								});
+							}
 						}
 					}
-				},0);
-			}
-
-			// Initialize the plugin late so that the injected DOM does not disrupt the template compiler
-			// ToDo: $timeout service
-			setTimeout(function(){
-				elm.select2(opts);
-				loaded = true;
-				// If a watch was fired before initialized, set the init value
-				initialize(prevVal);
-			},0);
-
-			// Watch the model for programmatic changes
-			scope.$watch(attrs.ngModel, function(newVal, oldVal, scope) {
-				if (newVal === prevVal) {
-					return;
 				}
-				if (loaded) {
-					initialize(newVal);
-					if (!newVal) {
-					    // Push the model change to the view(only the null value in this case)
-					    elm.select2('val', '');
-					}
-				}
-				prevVal = newVal;
-			});
-			// If you want you can watch the options dataset for changes
-			if (angular.isString(opts.watch)) {
-				scope.$watch(opts.watch, function(newVal, oldVal, scope){
-					if (loaded && prevVal) {
-						setTimeout(function(){
-							elm.select2('val', prevVal);
-						},0);
-					}
+
+				attrs.$observe('disabled', function(value){
+					elm.select2(value && 'disable' || 'enable');
+				});
+
+				// Set initial value since Angular doesn't
+				elm.val(scope.$eval(attrs.ngModel));
+
+				// Initialize the plugin late so that the injected DOM does not disrupt the template compiler
+				setTimeout(function(){
+					elm.select2(opts);
 				});
 			}
 		}


### PR DESCRIPTION
Completely redone from the ground up. Relies on the latest version of Select2 (I had to address ivaynberg/select2#230 for this to work).

You can view a very rich demo here: http://plunker.no.de/edit/ZuKcDq?live=preview
## Improvements
- When working with an <input>, the value will now be an object instead of a string
  - You can set the value using an object
  - Once ivaynberg/select2#224 is closed, you will be able to set the value using a string (Select2 will query the extra information)
- The initial query is now done by Select2 instead of the directive, letting you leverage the `initSelection` option
  - The custom `initial` option has now been removed
  - No unnecessary ajax calls are being performed when the first value is selected (occurred when there was no default)
- The custom `watch` option has now been dropped as it is now being introspected at compile time
- The `disabled` attribute is now monitored and reflected by select2
- Closes #21
