### PR TITLE
fixes issue #62: CodeMirror expects a string

### DIFF
--- a/modules/directives/codemirror/src/codemirror.js
+++ b/modules/directives/codemirror/src/codemirror.js
@@ -53,20 +53,17 @@ angular.module('ui.directives').directive('uiCodemirror', ['ui.config', '$parse'
             // Now watch to see if the codemirror attribute gets updated
             scope.$watch(uiCodemirrorGet, updateCodeMirror, true);
 
+            ngModel.$formatters.push(function(value) {
+                if(!angular.isString(value)) {
+                    return '';
+                }
+                return value;
+            });
+
             // Override the ngModelController $render method, which is what gets called when the model is updated.
             // This takes care of the synchronizing the codeMirror element with the underlying model, in the case that it is changed by something else.
             ngModel.$render = function() {
-                if(angular.isString(ngModel.$viewValue)) {
-                    codemirror.setValue(ngModel.$viewValue);
-                } else {
-                    // momentarily stub out the change handler.  we want to keep the model
-                    // value, but CodeMirror wants a string, so we pass it an empty string
-                    // and keep the model the same.
-                    var changeHandler = codemirror.getOption('onChange');
-                    codemirror.setOption('onChange', angular.noop);
-                    codemirror.setValue('');
-                    codemirror.setOption('onChange', changeHandler);
-                }
+                codemirror.setValue(ngModel.$viewValue);
             };
        }
     };

--- a/modules/directives/codemirror/src/codemirror.js
+++ b/modules/directives/codemirror/src/codemirror.js
@@ -56,7 +56,17 @@ angular.module('ui.directives').directive('uiCodemirror', ['ui.config', '$parse'
             // Override the ngModelController $render method, which is what gets called when the model is updated.
             // This takes care of the synchronizing the codeMirror element with the underlying model, in the case that it is changed by something else.
             ngModel.$render = function() {
-                codemirror.setValue(ngModel.$viewValue);
+                if(angular.isString(ngModel.$viewValue)) {
+                    codemirror.setValue(ngModel.$viewValue);
+                } else {
+                    // momentarily stub out the change handler.  we want to keep the model
+                    // value, but CodeMirror wants a string, so we pass it an empty string
+                    // and keep the model the same.
+                    var changeHandler = codemirror.getOption('onChange');
+                    codemirror.setOption('onChange', angular.noop);
+                    codemirror.setValue('');
+                    codemirror.setOption('onChange', changeHandler);
+                }
             };
        }
     };

--- a/modules/directives/codemirror/src/codemirror.js
+++ b/modules/directives/codemirror/src/codemirror.js
@@ -1,14 +1,17 @@
+/*global angular, CodeMirror, Error*/
 /**
  * Binds a CodeMirror widget to a <textarea> element.
  */
 angular.module('ui.directives').directive('uiCodemirror', ['ui.config', '$parse', function (uiConfig, $parse) {
+    'use strict';
+
     uiConfig.codemirror = uiConfig.codemirror || {};
     return {
         require: 'ngModel',
         link: function (scope, elm, attrs, ngModel) {
             // Only works on textareas
             if ( !elm.is('textarea') ) {
-                throw Error('ui-codemirror can only be applied to a textarea element');
+                throw new Error('ui-codemirror can only be applied to a textarea element');
             }
 
             var codemirror;
@@ -58,6 +61,9 @@ angular.module('ui.directives').directive('uiCodemirror', ['ui.config', '$parse'
             ngModel.$formatters.push(function(value) {
                 if(angular.isUndefined(value) || value === null) {
                     return '';
+                }
+                else if (angular.isObject(value) || angular.isArray(value)) {
+                    throw new Error('ui-codemirror cannot use an object or an array as a model');
                 }
                 return value;
             });

--- a/modules/directives/codemirror/src/codemirror.js
+++ b/modules/directives/codemirror/src/codemirror.js
@@ -53,6 +53,8 @@ angular.module('ui.directives').directive('uiCodemirror', ['ui.config', '$parse'
             // Now watch to see if the codemirror attribute gets updated
             scope.$watch(uiCodemirrorGet, updateCodeMirror, true);
 
+            // CodeMirror expects a string, so make sure it gets one.
+            // This does not change the model.
             ngModel.$formatters.push(function(value) {
                 if(!angular.isString(value)) {
                     return '';

--- a/modules/directives/codemirror/src/codemirror.js
+++ b/modules/directives/codemirror/src/codemirror.js
@@ -56,7 +56,7 @@ angular.module('ui.directives').directive('uiCodemirror', ['ui.config', '$parse'
             // CodeMirror expects a string, so make sure it gets one.
             // This does not change the model.
             ngModel.$formatters.push(function(value) {
-                if(!angular.isString(value)) {
+                if(angular.isUndefined(value) || value === null) {
                     return '';
                 }
                 return value;

--- a/modules/directives/codemirror/test/codemirrorSpec.js
+++ b/modules/directives/codemirror/test/codemirrorSpec.js
@@ -77,12 +77,6 @@ describe('uiCodemirror', function () {
     describe('when the model is falsy', function () {
         it('should update the IDE with an empty string', function () {
             inject(function ($compile) {
-                var codemirror,
-                    fromTextArea = CodeMirror.fromTextArea;
-                spyOn(CodeMirror, 'fromTextArea').andCallFake(function () {
-                    codemirror = fromTextArea.apply(this, arguments);
-                    return codemirror;
-                });
                 var element = $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
                 scope.$apply();
                 expect(scope.foo).toBe(undefined);

--- a/modules/directives/codemirror/test/codemirrorSpec.js
+++ b/modules/directives/codemirror/test/codemirrorSpec.js
@@ -74,12 +74,16 @@ describe('uiCodemirror', function () {
             });
         });
     });
-    describe('when the model is falsy', function () {
+    describe('when the model is undefined/null', function () {
         it('should update the IDE with an empty string', function () {
             inject(function ($compile) {
                 var element = $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
                 scope.$apply();
                 expect(scope.foo).toBe(undefined);
+                expect(element.siblings().text().trim()).toBe('');
+                scope.foo = null;
+                scope.$apply();
+                expect(scope.foo).toBe(null);
                 expect(element.siblings().text().trim()).toBe('');
             });
         });

--- a/modules/directives/codemirror/test/codemirrorSpec.js
+++ b/modules/directives/codemirror/test/codemirrorSpec.js
@@ -88,4 +88,22 @@ describe('uiCodemirror', function () {
             });
         });
     });
+    describe('when the model is an object or an array', function() {
+        it('should throw an error', function() {
+            inject(function ($compile) {
+                function compileWithObject() {
+                    $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
+                    scope.foo = {};
+                    scope.$apply();
+                }
+                function compileWithArray() {
+                    $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
+                    scope.foo = [];
+                    scope.$apply();
+                }
+                expect(compileWithObject).toThrow();
+                expect(compileWithArray).toThrow();
+            });
+        });
+    });
 });

--- a/modules/directives/codemirror/test/codemirrorSpec.js
+++ b/modules/directives/codemirror/test/codemirrorSpec.js
@@ -74,4 +74,20 @@ describe('uiCodemirror', function () {
             });
         });
     });
+    describe('when the model is falsy', function () {
+        it('should update the IDE with an empty string', function () {
+            inject(function ($compile) {
+                var codemirror,
+                    fromTextArea = CodeMirror.fromTextArea;
+                spyOn(CodeMirror, 'fromTextArea').andCallFake(function () {
+                    codemirror = fromTextArea.apply(this, arguments);
+                    return codemirror;
+                });
+                var element = $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
+                scope.$apply();
+                expect(scope.foo).toBe(undefined);
+                expect(element.siblings().text().trim()).toBe('');
+            });
+        });
+    });
 });


### PR DESCRIPTION
This was my approach to fixing issue #62.  We want to call setValue() basically but we do not want the onChange function to fire, so this avoids that.  I don't know if this is safe, but the test proves it works.
