### PR TITLE
Fixing problem with an empty string as filter

### DIFF
--- a/modules/filters/highlight/highlight.js
+++ b/modules/filters/highlight/highlight.js
@@ -5,7 +5,7 @@
  */
 angular.module('ui.filters').filter('highlight', function() {
 	return function(text, filter) {
-		if (filter === undefined) {
+    if (!filter) {
 			return text;
 		} else {
 			return text.replace(new RegExp(filter, 'gi'), '<span class="ui-match">$&</span>');

--- a/modules/filters/highlight/test/highlightSpec.js
+++ b/modules/filters/highlight/test/highlightSpec.js
@@ -12,4 +12,13 @@ describe('highlight', function() {
   it('should highlight nothing if no match found', function() {
     expect(highlightFilter(testPhrase, 'no match')).toEqual(testPhrase);
   });
+  it('should highlight nothing for the undefined filter', function() {
+    expect(highlightFilter(testPhrase, undefined)).toEqual(testPhrase);
+  });
+  it('should work correctly for number filters', function() {
+    expect(highlightFilter('3210123', 0)).toEqual('321<span class="ui-match">0</span>123');
+  });
+  it('should highlight nothing if empty filter string passed - issue #114', function() {
+    expect(highlightFilter(testPhrase, '')).toEqual(testPhrase);
+  });
 })


### PR DESCRIPTION
Fix for the issue #114. The problem was that an empty string passed as a highlight filter was adding a span over each and every character. 
