### PR TITLE
Fix links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The repository comes with the modules pre-built and compressed into the `build/`
 angular.module('myApp', ['ui']);
 ```
 
-The modules can be found in the [Directives](http://github.com/angular-ui/angular-ui/modules/directives) and [Filters](http://github.com/angular-ui/angular-ui/modules/filters) folders. Check out the readme file associated with each module for specific module usage information.
+The modules can be found in the [Directives](https://github.com/angular-ui/angular-ui/tree/master/modules/directives) and [Filters](https://github.com/angular-ui/angular-ui/tree/master/modules/filters) folders. Check out the readme file associated with each module for specific module usage information.
 
 ## Development
 


### PR DESCRIPTION
Currently both links to [directives](https://github.com/angular-ui/angular-ui/modules/directives) and [filters](https://github.com/angular-ui/angular-ui/modules/filters) lead to 404 page.
