### PR TITLE
Ui validate directive

### DIFF
--- a/modules/directives/validate/test/validateSpec.js
+++ b/modules/directives/validate/test/validateSpec.js
@@ -1,0 +1,99 @@
+describe('uiValidate', function ($compile) {
+  var scope, compileAndDigest;
+
+  beforeEach(module('ui'));
+  beforeEach(inject(function ($rootScope, $compile) {
+    
+    scope = $rootScope.$new();
+    compileAndDigest = function (inputHtml, scope) {
+
+      var inputElm = angular.element(inputHtml);
+      var formElm =  angular.element('<form name="form"></form>');
+      formElm.append(inputElm);
+      $compile(formElm)(scope);
+      scope.$digest();
+
+      return inputElm;
+    };
+  }));
+
+  describe('initial validation', function () {
+
+    it('should mark input as valid if initial model is valid', inject(function () {
+
+      scope.validate = function () {
+        return true
+      };
+      compileAndDigest('<input name="input" ng-model="value" ui-validate="validate">', scope);
+      expect(scope.form.input.$valid).toBeTruthy();
+      expect(scope.form.input.$error).toEqual({validator : false});
+    }));
+
+    it('should mark input as invalid if initial model is invalid', inject(function () {
+
+      scope.validate = function () {
+        return false
+      };
+      compileAndDigest('<input name="input" ng-model="value" ui-validate="validate">', scope);
+      expect(scope.form.input.$valid).toBeFalsy();
+      expect(scope.form.input.$error).toEqual({ validator : true });
+    }));
+  });
+
+  describe('validation on model change', function () {
+
+    it('should change valid state in response to model changes', inject(function () {
+
+      scope.value = false;
+      scope.validate = function (valueToValidate) {
+        return valueToValidate;
+      };
+      compileAndDigest('<input name="input" ng-model="value" ui-validate="validate">', scope);
+      expect(scope.form.input.$valid).toBeFalsy();
+
+      scope.$apply('value = true');
+      expect(scope.form.input.$valid).toBeTruthy();
+    }));
+  });
+
+  describe('validation on element change', function () {
+
+    var sniffer;
+    beforeEach(inject(function ($sniffer) {
+      sniffer = $sniffer;
+    }));
+
+    it('should change valid state in response to element events', inject(function () {
+
+      scope.value = false;
+      scope.validate = function (valueToValidate) {
+        return valueToValidate;
+      };
+      var inputElm = compileAndDigest('<input name="input" ng-model="value" ui-validate="validate">', scope);
+      expect(scope.form.input.$valid).toBeFalsy();
+
+      inputElm.val('true');
+      inputElm.trigger((sniffer.hasEvent('input') ? 'input' : 'change'));
+
+      expect(scope.form.input.$valid).toBeTruthy();
+    }));
+  });
+
+  describe('error cases', function () {
+    it('should fail if ngModel not present', inject(function () {
+      expect(function () {
+        compileAndDigest('<input name="input" ui-validate="validate">', scope);
+      }).toThrow(new Error('No controller: ngModel'));
+    }));
+
+    it('should fail with an exception if validate expression is not a function', inject(function () {
+      expect(function () {
+        compileAndDigest('<input name="input" ng-model="value" ui-validate="value">', scope);
+      }).toThrow(new Error('uiValidate expression "value" is not a function.'));
+    }));
+
+    it('should have no effect if validate expression is empty', inject(function () {
+      compileAndDigest('<input ng-model="value" ui-validate="">', scope);
+    }));
+  });
+});

--- a/modules/directives/validate/validate.js
+++ b/modules/directives/validate/validate.js
@@ -1,0 +1,48 @@
+/**
+ * General-purpose validator for ngModel.
+ * angular.js comes with several built-in validation mechanism for input fields (ngRequired, ngPattern etc.) but using
+ * an arbitrary validation function requires creation of a custom formatters and / or parsers.
+ * The ui-validate directive makes it easy to use any function defined in scope as a validator function. The validator
+ * function will trigger validation on both model and input changes.
+ *
+ * @example <input ui-validate="myValidatorFunction">
+ *
+ * @param ui-validate {string} The name of a function to be used as a validator. The function will get a value to be
+ * validates as its argument and should return true/false indicating a validation result.
+ */
+angular.module('ui.directives').directive('uiValidate', function ($parse) {
+
+  return {
+    restrict:'A',
+    require:'ngModel',
+    link:function (scope, elm, attrs, ctrl) {
+
+      var validateExpr = attrs.uiValidate || '';
+      if (validateExpr.length === 0) {
+        return;
+      }
+
+      if (!angular.isFunction(scope[validateExpr])){
+        throw Error('uiValidate expression "'+validateExpr+'" is not a function.');
+      }
+
+      var validateFn = function (valueToValidate) {
+
+        if (scope[validateExpr](valueToValidate)) {
+          // it is valid
+          ctrl.$setValidity('validator', true);
+          return valueToValidate;
+        } else {
+          // it is invalid, return undefined (no model update)
+          ctrl.$setValidity('validator', false);
+          return undefined;
+        }
+      };
+
+      if (ctrl) {
+        ctrl.$formatters.push(validateFn);
+        ctrl.$parsers.push(validateFn);
+      }
+    }
+  }
+});

--- a/modules/directives/validate/validate.js
+++ b/modules/directives/validate/validate.js
@@ -10,7 +10,7 @@
  * @param ui-validate {string} The name of a function to be used as a validator. The function will get a value to be
  * validates as its argument and should return true/false indicating a validation result.
  */
-angular.module('ui.directives').directive('uiValidate', function ($parse) {
+angular.module('ui.directives').directive('uiValidate', function () {
 
   return {
     restrict:'A',
@@ -22,8 +22,8 @@ angular.module('ui.directives').directive('uiValidate', function ($parse) {
         return;
       }
 
-      if (!angular.isFunction(scope[validateExpr])){
-        throw Error('uiValidate expression "'+validateExpr+'" is not a function.');
+      if (!angular.isFunction(scope[validateExpr])) {
+        throw Error('uiValidate expression "' + validateExpr + '" is not a function.');
       }
 
       var validateFn = function (valueToValidate) {
@@ -39,10 +39,8 @@ angular.module('ui.directives').directive('uiValidate', function ($parse) {
         }
       };
 
-      if (ctrl) {
-        ctrl.$formatters.push(validateFn);
-        ctrl.$parsers.push(validateFn);
-      }
+      ctrl.$formatters.push(validateFn);
+      ctrl.$parsers.push(validateFn);
     }
   }
 });


### PR DESCRIPTION
As discussed on the mailing list this is the first implementation of uiValidate directive (with tests). For now it just supports one validator function and has validation key fixed as 'validator'. There are many extensions possible, notably:
- supporting custom validation keys, 2 syntax proposal below:
  - `ui-validate='myFunction as validationKey'`
  - making it possible for validator functions to return objects like: `{validationKey:true}`
- supporting many validation functions, 2 syntax proposal below:
  - `ui-validate='{validationFunction1 : validationKey1, validationFunction2 : validationKey2}'
  - having one validator function as input but making it possible to return many validation results like `{validationKey1:true, validationKey2:false}`
- supporting any expression as a validator function: `ui-validate='myFunction($value)'`
