### PR TITLE
Fix for the IE8 issue #106

### DIFF
--- a/modules/directives/keypress/keypress.js
+++ b/modules/directives/keypress/keypress.js
@@ -47,7 +47,12 @@ angular.module('ui.directives').directive('uiKeypress', ['$parse', function($par
           combination.expression = $parse(v[0]);
           combination.keys = v[1];
         }
-        combination.keys = combination.keys.split('-');
+
+        keys = {};
+        angular.forEach(combination.keys.split('-'), function(value) {
+          keys[value] = true;
+        });
+        combination.keys = keys;
         combinations.push(combination);
       });
 
@@ -60,11 +65,12 @@ angular.module('ui.directives').directive('uiKeypress', ['$parse', function($par
 
         // Iterate over prepared combinations
         angular.forEach(combinations, function(combination) {
-          var mainKeyPressed = combination.keys.indexOf( keysByCode[event.keyCode] ) > -1 || combination.keys.indexOf( event.keyCode.toString() ) > -1
 
-          var altRequired   =  combination.keys.indexOf('alt')   > -1;
-          var ctrlRequired  =  combination.keys.indexOf('ctrl')  > -1;
-          var shiftRequired =  combination.keys.indexOf('shift') > -1;
+          var mainKeyPressed = (combination.keys[keysByCode[event.keyCode]] || combination.keys[event.keyCode.toString()]) || false;
+
+          var altRequired   =  combination.keys.alt || false;
+          var ctrlRequired  =  combination.keys.ctrl || false;
+          var shiftRequired =  combination.keys.shift || false;
 
           if( mainKeyPressed &&
               ( altRequired   == altPressed   ) &&

--- a/modules/directives/keypress/test/keypressSpec.js
+++ b/modules/directives/keypress/test/keypressSpec.js
@@ -15,7 +15,7 @@ describe('uiKeypress', function () {
 
   var createElement = function (elementDef) {
     var elementStr = angular.isString(elementDef) ? elementDef : angular.toJson(elementDef);
-    return $compile("<span ui-keypress='" + elementStr + "'>")($scope);
+    return $compile("<span ui-keypress='" + elementStr + "'></span>")($scope);
   };
 
   beforeEach(module('ui.directives'));


### PR DESCRIPTION
Fixes #106
The issue was usage of Array.indexOf that is not supported in IE8... Just wonder if we should a set of utilities to deal with those cross-browser issues or simply use jQuery. I'm trying to avoid using jQuery if not absolutely mandatory but I guess it doesn't make much sense since we DO require jQuery. Somehow I prefer angular.js utilities versus jQuery utilities but I'm not sure I can explain why :-)
