### PR TITLE
Added a new Extract and Format filter with test

### DIFF
--- a/modules/filters/extract/extract.js
+++ b/modules/filters/extract/extract.js
@@ -1,0 +1,38 @@
+
+/**
+ * Extracts properties of an array of objects and returns an array of strings
+ *
+ * @TODO Make paths go deeper than 1 level
+ * @TODO Allow an array for separator param?
+ * @param dataset {array[object]} array of objects to extract from
+ * @param paths {mixed} the property to retrieve from the objects
+ *   string: property name
+ *   array[string]: array of property names to be joined by separator in the order passed
+ * @param [separator] {string} Optional the string to join multiple properties
+ */
+angular.module('ui.filters').filter('extract', function(){
+  // paths can optionally be an array
+  // separator is how to merge those different paths
+  return function(value, paths, separator) {
+    var result = [],
+        newItem;
+    if (angular.isArray(value) || angular.isObject(value)) {
+      angular.forEach(value, function(item) {
+        // if paths is an array
+        if (angular.isArray(paths)) {
+          newItem = [];
+          angular.forEach(paths, function(path){
+            newItem.push(item[path]);
+          });
+          result.push(newItem.join(separator));
+        // if paths is a string
+        } else {
+          result.push(item[paths]);
+        }
+      });
+    } else {
+      result = value;
+    }
+    return result;
+  };
+});

--- a/modules/filters/extract/test/extractSpec.js
+++ b/modules/filters/extract/test/extractSpec.js
@@ -1,0 +1,49 @@
+describe('extract', function() {
+  var extractFilter, testData = [
+    { firstName: 'Igor', lastName: 'Minar', age: '10' },
+    { firstName: 'Dean', lastName: 'Sofer', age: '20' },
+    { firstName: 'Jason', lastName: 'Stathom', age: '30' }
+  ];
+
+  beforeEach(module('ui.filters'));
+  beforeEach(inject(function($filter) {
+    extractFilter = $filter('extract');
+  }));
+
+  it('should return an array of properties', function() {
+    expect(extractFilter(testData, 'extract')).toEqual('Prefix <span class="ui-match">extract</span> Suffix');
+  });
+  it('should extract nothing if no match found', function() {
+    expect(extractFilter(testData, 'no match')).toEqual(testData);
+  });
+  it('should extract nothing for the undefined filter', function() {
+    expect(extractFilter(testData, undefined)).toEqual(testData);
+  });
+  it('should work correctly for number filters', function() {
+    expect(extractFilter('3210123', 0)).toEqual('321<span class="ui-match">0</span>123');
+  });
+  it('should work correctly for number text', function() {
+    expect(extractFilter(3210123, '0')).toEqual('321<span class="ui-match">0</span>123');
+  });
+  it('should extract a matching phrase', function() {
+    expect(extractFilter(testData, 'extract', true)).toEqual('Prefix <span class="ui-match">extract</span> Suffix');
+  });
+  it('should extract nothing if no match found', function() {
+    expect(extractFilter(testData, 'no match', true)).toEqual(testData);
+  });
+  it('should extract nothing for the undefined filter', function() {
+    expect(extractFilter(testData, undefined, true)).toEqual(testData);
+  });
+  it('should work correctly for number filters', function() {
+    expect(extractFilter('3210123', 0, true)).toEqual('321<span class="ui-match">0</span>123');
+  });
+  it('should work correctly for number text', function() {
+    expect(extractFilter(3210123, '0', true)).toEqual('321<span class="ui-match">0</span>123');
+  });
+  it('should not extract a phrase with different letter-casing', function() {
+    expect(extractFilter(testData, 'extract', true)).toEqual(testData);
+  });
+  it('should extract nothing if empty filter string passed - issue #114', function() {
+    expect(extractFilter(testData, '')).toEqual(testData);
+  });
+});

--- a/modules/filters/format/format.js
+++ b/modules/filters/format/format.js
@@ -1,0 +1,34 @@
+
+/**
+ * A replacement utility for internationalization very similar to sprintf.
+ *
+ * @param replace {mixed} The tokens to replace depends on type
+ *  string: all instances of $0 will be replaced
+ *  array: each instance of $0, $1, $2 etc. will be placed with each array item in corresponding order
+ *  object: all attributes will be iterated through, with :key being replaced with its corresponding value
+ * @return string
+ *
+ * @example: 'Hello :name, how are you :day'.format({ name:'John', day:'Today' })
+ * @example: 'Records $0 to $1 out of $2 total'.format(['10', '20', '3000'])
+ * @example: '$0 agrees to all mentions $0 makes in the event that $0 hits a tree while $0 is driving drunk'.format('Bob')
+ */
+angular.module('ui.filters').filter('format', function(){
+  return function(value, replace) {
+    if (!value) {
+      return value;
+    }
+    var target = value.toString(), token;
+    if (replace === undefined) {
+      return target;
+    }
+    if (!angular.isArray(replace) && !angular.isObject(replace)) {
+      return target.split('$0').join(replace);
+    }
+    token = angular.isArray(replace) && '$' || ':';
+
+    angular.forEach(replace, function(value, key){
+      target = target.split(token+key).join(value);
+    });
+    return target;
+  };
+});

--- a/modules/filters/format/test/formatSpec.js
+++ b/modules/filters/format/test/formatSpec.js
@@ -1,0 +1,21 @@
+describe('format', function() {
+  var formatFilter;
+
+  beforeEach(module('ui.filters'));
+  beforeEach(inject(function($filter) {
+    formatFilter = $filter('format');
+  }));
+
+  it('should replace all instances of $0 if string token is passed', function() {
+    expect(formatFilter('First $0, then $0, finally $0', 'bob')).toEqual('First bob, then bob, finally bob');
+  });
+  it('should replace all instances of $n based on order of token array', function() {
+    expect(formatFilter('First $0, then $1, finally $2', ['bob','frank','dianne'])).toEqual('First is bob, then frank, finally dianne');
+  });
+  it('should replace all instances :tokens based on keys of token object', function() {
+    expect(formatFilter('First is :first, next is :second, finally there is :third', {first:'bob',second:'frank',third:'dianne'})).toEqual('First is bob, then frank, finally dianne');
+  });
+  it('should do nothing if tokens are undefined', function() {
+    expect(formatFilter('Hello There')).toEqual('Hello There');
+  });
+});


### PR DESCRIPTION
Extract returns a new array of strings based on the paths. Ideally paths will allow us to traverse more deeply than one layer, but for now it's only 1 level deep. You can pass a separator and an array of paths to merge together multiple properties of the object. Useful for an array of people and you want to create a list of firrstName lastName, etc.

It returns an array which you can wrap and call join() on. Example:

``` html
<pre ng-bind-html-unsafe="(data|extract:['name','age']:': ').join('\n')"></pre>
```

Format is an i18n utility that I use that I actually put on the string prototype. Half of our filters I wonder might perhaps be better suited on the primitive prototypes. Anyway, it lets you swap out tokens from the string. It's very flexible and powerful. Example:

``` html
<pre>{{'Hello :name, how is the :object :day'|format:{name:'Bob',object:'sun',day:'tomorrow'} }}</pre>
```
