### PR TITLE
reformatted all code to use 2 spaces for tabs.  moved bootstrap code lib...

### DIFF
--- a/common/ieshiv/ieshiv.js
+++ b/common/ieshiv/ieshiv.js
@@ -1,77 +1,79 @@
 // READ: http://docs-next.angularjs.org/guide/ie
-(function(exports){
-  
+(function (exports) {
+
   var debug = window.ieShivDebug || false;
-  
-  var getIE = function() {
-      // Returns the version of Internet Explorer or a -1
-      // (indicating the use of another browser).
-     var rv = -1; // Return value assumes failure.
-     if (navigator.appName == 'Microsoft Internet Explorer') {
-        var ua = navigator.userAgent;
-        var re  = new RegExp("MSIE ([0-9]{1,}[\.0-9]{0,})");
-        if (re.exec(ua) != null) {
-        	rv = parseFloat( RegExp.$1 );
+
+  var getIE = function () {
+    // Returns the version of Internet Explorer or a -1
+    // (indicating the use of another browser).
+    var rv = -1; // Return value assumes failure.
+    if (navigator.appName == 'Microsoft Internet Explorer') {
+      var ua = navigator.userAgent;
+      var re = new RegExp("MSIE ([0-9]{1,}[\.0-9]{0,})");
+      if (re.exec(ua) != null) {
+        rv = parseFloat(RegExp.$1);
+      }
+    }
+    return rv;
+  };
+
+  var toCustomElements = function (str, delim) {
+    var result = [];
+    var dashed = str.replace(/([A-Z])/g, function ($1) {
+      return " " + $1.toLowerCase();
+    });
+    var tokens = dashed.split(' ');
+    var ns = tokens[0];
+    var dirname = tokens.slice(1).join('-');
+
+    // this is finite list and it seemed senseless to create a custom method
+    result.push(ns + ":" + dirname);
+    result.push(ns + "-" + dirname);
+    result.push("x-" + ns + "-" + dirname);
+    result.push("data-" + ns + "-" + dirname);
+    return result;
+  };
+
+  var shiv = function () {
+    // TODO: unfortunately, angular is not exposing these in 'ng' module
+    var tags = [ 'ngInclude', 'ngPluralize', 'ngView', 'ngSwitch' ]; // angular specific,
+
+    // TODO: unfortunately, angular does not expose module names, it is a simple change to angular's loader.js
+    // however, not sure if something happens when referencing them, so maybe an OK thing.
+
+    var moduleNames = window.myAngularModules || []; // allow user to inject their own directives
+    moduleNames.push('ui.directives');
+
+    if (debug) console.log('moduleNames', moduleNames);
+    for (var k = 0, mlen = moduleNames.length; k < mlen; k++) {
+      var modules = angular.module(moduleNames[k]); // will throw runtime exception
+      angular.forEach(modules._invokeQueue, function (item) {
+        // only allow directives
+        if (item[1] === "directive") {
+          var dirname = item[2][0];
+          tags.push(dirname);
+        } else {
+          if (debug) console.log("skipping", item[1], item[2][0]);
         }
-     }
-     return rv;
-  };
+      });
+    }
 
-  var toCustomElements = function(str,delim) {
-	  var result = [];
-	  var dashed = str.replace(/([A-Z])/g, function($1) { return " "+$1.toLowerCase();} );
-      var tokens = dashed.split(' ');
-      var ns = tokens[0];
-      var dirname = tokens.slice(1).join('-');
-      
-      // this is finite list and it seemed senseless to create a custom method
-      result.push(ns + ":" + dirname);
-      result.push(ns + "-" + dirname);
-      result.push("x-" + ns + "-" + dirname);
-      result.push("data-" + ns + "-" + dirname);
-      return result;
-  };
-
-  var shiv = function() {
-	// TODO: unfortunately, angular is not exposing these in 'ng' module
-	var tags = [ 'ngInclude', 'ngPluralize', 'ngView', 'ngSwitch' ]; // angular specific, 
-	
-	// TODO: unfortunately, angular does not expose module names, it is a simple change to angular's loader.js
-	// however, not sure if something happens when referencing them, so maybe an OK thing.
-	
-	var moduleNames = window.myAngularModules || []; // allow user to inject their own directives
-	moduleNames.push('ui.directives');
-	
-	if(debug) console.log('moduleNames', moduleNames);
-	for(var k = 0, mlen = moduleNames.length; k < mlen; k++) {
-		var modules = angular.module(moduleNames[k]); // will throw runtime exception
-		angular.forEach(modules._invokeQueue, function(item) {
-	      // only allow directives
-		  if(item[1] === "directive") {
-	        var dirname = item[2][0];
-	        tags.push(dirname);
-		  } else {
-			  if(debug) console.log("skipping",item[1], item[2][0]);
-		  }
-		});
-	}
-	
-	if(debug) console.log("tags found", tags);
-    for(var i = 0, tlen = tags.length; i < tlen; i++) {
-    	if(debug) console.log("tag",tags[i]);
-    	var customElements = toCustomElements(tags[i],':');
-    	for(var j = 0, clen = customElements.length; j < clen; j++) {
-    		var customElement = customElements[j];
-    		if(debug) console.log("shivving",customElement);
-    		document.createElement(customElement);
-    	}
+    if (debug) console.log("tags found", tags);
+    for (var i = 0, tlen = tags.length; i < tlen; i++) {
+      if (debug) console.log("tag", tags[i]);
+      var customElements = toCustomElements(tags[i], ':');
+      for (var j = 0, clen = customElements.length; j < clen; j++) {
+        var customElement = customElements[j];
+        if (debug) console.log("shivving", customElement);
+        document.createElement(customElement);
+      }
     }
   };
-	
+
   var ieVersion = getIE();
-  
+
   if ((ieVersion > -1 && ieVersion < 9) || debug) {
     shiv();
   }
-  
+
 })(window);

--- a/grunt.js
+++ b/grunt.js
@@ -1,7 +1,7 @@
 var testacular = require('testacular');
 
 /*global module:false*/
-module.exports = function(grunt) {
+module.exports = function (grunt) {
 
   grunt.loadNpmTasks('grunt-recess');
   grunt.loadNpmTasks('grunt-coffee');
@@ -69,22 +69,22 @@ module.exports = function(grunt) {
   // Default task.
   grunt.registerTask('default', 'coffee concat min recess:basic recess:min test');
 
-  grunt.registerTask('server', 'start testacular server', function() {
+  grunt.registerTask('server', 'start testacular server', function () {
     //Mark the task as async but never call done, so the server stays up
     var done = this.async();
     testacular.server.start('test/test-config.js');
   });
 
-  grunt.registerTask('test', 'run tests (make sure server task is run first)', function() {
+  grunt.registerTask('test', 'run tests (make sure server task is run first)', function () {
     var done = this.async();
     grunt.utils.spawn({
       cmd: process.platform === 'win32' ? 'testacular-run.cmd' : 'testacular-run',
       args: ['test/test-config.js']
-    }, function(error, result, code) {
+    }, function (error, result, code) {
       if (error) {
-        grunt.warn("Make sure the testacular server is online: run `grunt server`.\n"+
-          "Also make sure you have a browser open to http://localhost:8080/.\n"+
-          error.stdout+error.stderr);
+        grunt.warn("Make sure the testacular server is online: run `grunt server`.\n" +
+          "Also make sure you have a browser open to http://localhost:8080/.\n" +
+          error.stdout + error.stderr);
         //the testacular runner somehow modifies the files if it errors(??).
         //this causes grunt's watch task to re-fire itself constantly,
         //unless we wait for a sec

--- a/modules/directives/animate/animate.js
+++ b/modules/directives/animate/animate.js
@@ -7,7 +7,7 @@
  *    class {string} the CSS class(es) to use. For example, 'ui-hide' might be an excellent alternative class.
  * @example <li ng-repeat="item in items" ui-animate=" 'ui-hide' ">{{item}}</li>
  */
-angular.module('ui.directives').directive('uiAnimate', ['ui.config', '$timeout', function(uiConfig, $timeout) {
+angular.module('ui.directives').directive('uiAnimate', ['ui.config', '$timeout', function (uiConfig, $timeout) {
   var options = {};
   if (angular.isString(uiConfig.animate)) {
     options['class'] = uiConfig.animate;
@@ -16,18 +16,18 @@ angular.module('ui.directives').directive('uiAnimate', ['ui.config', '$timeout',
   }
   return {
     restrict: 'A', // supports using directive as element, attribute and class
-    link: function($scope, element, attrs) {
+    link: function ($scope, element, attrs) {
       var opts = {};
       if (attrs.uiAnimate) {
         opts = $scope.$eval(attrs.uiAnimate);
         if (angular.isString(opts)) {
-          opts = {'class':  opts};
+          opts = {'class': opts};
         }
       }
       opts = angular.extend({'class': 'ui-animate'}, options, opts);
-      
+
       element.addClass(opts['class']);
-      $timeout(function(){
+      $timeout(function () {
         element.removeClass(opts['class']);
       }, 20, false);
     }

--- a/modules/directives/animate/test/animateSpec.js
+++ b/modules/directives/animate/test/animateSpec.js
@@ -1,7 +1,7 @@
 /*
  * sample unit testing for sample templates and implementations
-*/
-describe('uiAnimate', function() {
+ */
+describe('uiAnimate', function () {
 
   // declare these up here to be global to all tests
   var $rootScope, $compile, $timeout, uiConfig = angular.module('ui.config');
@@ -10,57 +10,57 @@ describe('uiAnimate', function() {
 
   // inject in angular constructs. Injector knows about leading/trailing underscores and does the right thing
   // otherwise, you would need to inject these into each test
-  beforeEach(inject(function(_$rootScope_, _$compile_, _$timeout_) {
+  beforeEach(inject(function (_$rootScope_, _$compile_, _$timeout_) {
     $rootScope = _$rootScope_;
     $compile = _$compile_;
     $timeout = _$timeout_;
   }));
-  
-  afterEach(function() {
+
+  afterEach(function () {
     uiConfig.value('ui.config', {});
   });
-  
-  describe('behavior', function() {
-    it('should add a ui-animate class when the dom is compiled', function() {
+
+  describe('behavior', function () {
+    it('should add a ui-animate class when the dom is compiled', function () {
       var element = $compile('<div ui-animate></div>')($rootScope);
       expect(element.hasClass('ui-animate')).toBeTruthy();
     });
-    it('should remove the ui-animate class immediately after injection', function() {
+    it('should remove the ui-animate class immediately after injection', function () {
       var element = $compile('<div ui-animate></div>')($rootScope);
       $timeout.flush();
       expect(element.hasClass('ui-animate')).toBeFalsy();
     });
 
   });
-  
-  describe('options', function() {
-    describe('passed', function() {
-      
-      it('should use a string as the class', function() {
+
+  describe('options', function () {
+    describe('passed', function () {
+
+      it('should use a string as the class', function () {
         var element = $compile('<div ui-animate=" \'ui-hide\' "></div>')($rootScope);
         expect(element.hasClass('ui-hide')).toBeTruthy();
       });
-      it('should use an object\'s class attribute as the class', function() {
+      it('should use an object\'s class attribute as the class', function () {
         var element = $compile('<div ui-animate=" { \'class\' : \'ui-hide\' } "></div>')($rootScope);
         expect(element.hasClass('ui-hide')).toBeTruthy();
       });
-    
+
     });
-    describe('global', function() {
+    describe('global', function () {
 
       var uiConfig;
-      beforeEach(inject(function($injector){
+      beforeEach(inject(function ($injector) {
         uiConfig = $injector.get('ui.config');
       }));
-      
-      it('should use a string as the class', function(){
+
+      it('should use a string as the class', function () {
         uiConfig.animate = 'ui-hide-global';
         var element = $compile('<div ui-animate></div>')($rootScope);
         expect(element.hasClass('ui-hide-global')).toBeTruthy();
       });
 
-      it('should use an object\'s class attribute as the class', function() {
-        uiConfig.animate = { 'class' : 'ui-hide-global' };
+      it('should use an object\'s class attribute as the class', function () {
+        uiConfig.animate = { 'class': 'ui-hide-global' };
         var element = $compile('<div ui-animate></div>')($rootScope);
         expect(element.hasClass('ui-hide-global')).toBeTruthy();
       });

--- a/modules/directives/codemirror/codemirror.js
+++ b/modules/directives/codemirror/codemirror.js
@@ -3,76 +3,76 @@
  * Binds a CodeMirror widget to a <textarea> element.
  */
 angular.module('ui.directives').directive('uiCodemirror', ['ui.config', '$parse', function (uiConfig, $parse) {
-    'use strict';
+  'use strict';
 
-    uiConfig.codemirror = uiConfig.codemirror || {};
-    return {
-        require: 'ngModel',
-        link: function (scope, elm, attrs, ngModel) {
-            // Only works on textareas
-            if ( !elm.is('textarea') ) {
-                throw new Error('ui-codemirror can only be applied to a textarea element');
-            }
+  uiConfig.codemirror = uiConfig.codemirror || {};
+  return {
+    require: 'ngModel',
+    link: function (scope, elm, attrs, ngModel) {
+      // Only works on textareas
+      if (!elm.is('textarea')) {
+        throw new Error('ui-codemirror can only be applied to a textarea element');
+      }
 
-            var codemirror;
-            // This is the method that we use to get the value of the ui-codemirror attribute expression.
-            var uiCodemirrorGet = $parse(attrs.uiCodemirror);
-            // This method will be called whenever the code mirror widget content changes
-            var onChangeHandler =  function (ed) {
-                // We only update the model if the value has changed - this helps get around a little problem where $render triggers a change despite already being inside a $apply loop.
-                var newValue = ed.getValue();
-                if ( newValue !== ngModel.$viewValue ) {
-                    ngModel.$setViewValue(newValue);
-                    scope.$apply();
-                }
-            };
-            // Create and wire up a new code mirror widget (unwiring a previous one if necessary)
-            var updateCodeMirror = function(options) {
-                // Merge together the options from the uiConfig and the attribute itself with the onChange event above.
-                options = angular.extend({}, options, uiConfig.codemirror);
+      var codemirror;
+      // This is the method that we use to get the value of the ui-codemirror attribute expression.
+      var uiCodemirrorGet = $parse(attrs.uiCodemirror);
+      // This method will be called whenever the code mirror widget content changes
+      var onChangeHandler = function (ed) {
+        // We only update the model if the value has changed - this helps get around a little problem where $render triggers a change despite already being inside a $apply loop.
+        var newValue = ed.getValue();
+        if (newValue !== ngModel.$viewValue) {
+          ngModel.$setViewValue(newValue);
+          scope.$apply();
+        }
+      };
+      // Create and wire up a new code mirror widget (unwiring a previous one if necessary)
+      var updateCodeMirror = function (options) {
+        // Merge together the options from the uiConfig and the attribute itself with the onChange event above.
+        options = angular.extend({}, options, uiConfig.codemirror);
 
-                // We actually want to run both handlers if the user has provided their own onChange handler.
-                var userOnChange = options.onChange;
-                if ( userOnChange ) {
-                    options.onChange = function(ed) {
-                        onChangeHandler(ed);
-                        userOnChange(ed);
-                    };
-                } else {
-                    options.onChange = onChangeHandler;
-                }
+        // We actually want to run both handlers if the user has provided their own onChange handler.
+        var userOnChange = options.onChange;
+        if (userOnChange) {
+          options.onChange = function (ed) {
+            onChangeHandler(ed);
+            userOnChange(ed);
+          };
+        } else {
+          options.onChange = onChangeHandler;
+        }
 
-                // If there is a codemirror widget for this element already then we need to unwire if first
-                if ( codemirror ) {
-                    codemirror.toTextArea();
-                }
-                // Create the new codemirror widget
-                codemirror = CodeMirror.fromTextArea(elm[0], options);
-            };
+        // If there is a codemirror widget for this element already then we need to unwire if first
+        if (codemirror) {
+          codemirror.toTextArea();
+        }
+        // Create the new codemirror widget
+        codemirror = CodeMirror.fromTextArea(elm[0], options);
+      };
 
-            // Initialize the code mirror widget
-            updateCodeMirror(uiCodemirrorGet());
+      // Initialize the code mirror widget
+      updateCodeMirror(uiCodemirrorGet());
 
-            // Now watch to see if the codemirror attribute gets updated
-            scope.$watch(uiCodemirrorGet, updateCodeMirror, true);
+      // Now watch to see if the codemirror attribute gets updated
+      scope.$watch(uiCodemirrorGet, updateCodeMirror, true);
 
-            // CodeMirror expects a string, so make sure it gets one.
-            // This does not change the model.
-            ngModel.$formatters.push(function(value) {
-                if(angular.isUndefined(value) || value === null) {
-                    return '';
-                }
-                else if (angular.isObject(value) || angular.isArray(value)) {
-                    throw new Error('ui-codemirror cannot use an object or an array as a model');
-                }
-                return value;
-            });
+      // CodeMirror expects a string, so make sure it gets one.
+      // This does not change the model.
+      ngModel.$formatters.push(function (value) {
+        if (angular.isUndefined(value) || value === null) {
+          return '';
+        }
+        else if (angular.isObject(value) || angular.isArray(value)) {
+          throw new Error('ui-codemirror cannot use an object or an array as a model');
+        }
+        return value;
+      });
 
-            // Override the ngModelController $render method, which is what gets called when the model is updated.
-            // This takes care of the synchronizing the codeMirror element with the underlying model, in the case that it is changed by something else.
-            ngModel.$render = function() {
-                codemirror.setValue(ngModel.$viewValue);
-            };
-       }
-    };
+      // Override the ngModelController $render method, which is what gets called when the model is updated.
+      // This takes care of the synchronizing the codeMirror element with the underlying model, in the case that it is changed by something else.
+      ngModel.$render = function () {
+        codemirror.setValue(ngModel.$viewValue);
+      };
+    }
+  };
 }]);

--- a/modules/directives/codemirror/test/codemirrorSpec.js
+++ b/modules/directives/codemirror/test/codemirrorSpec.js
@@ -1,118 +1,121 @@
 /*global beforeEach, afterEach, describe, it, inject, expect, module, spyOn, CodeMirror, angular, $*/
 describe('uiCodemirror', function () {
-    'use strict';
+  'use strict';
 
-    var scope, $compile;
-    beforeEach(function() {
-        // throw some garbage in the codemirror cfg to be sure it's getting thru to the directive
-        angular.module('ui.config').value('ui.config', {codemirror: {bar: 'baz'}});
-    });
-    beforeEach(module('ui'));
-    beforeEach(inject(function (_$rootScope_, _$compile_) {
-        scope = _$rootScope_.$new();
-        $compile = _$compile_;
-    }));
+  var scope, $compile;
+  beforeEach(function () {
+    // throw some garbage in the codemirror cfg to be sure it's getting thru to the directive
+    angular.module('ui.config').value('ui.config', {codemirror: {bar: 'baz'}});
+  });
+  beforeEach(module('ui'));
+  beforeEach(inject(function (_$rootScope_, _$compile_) {
+    scope = _$rootScope_.$new();
+    $compile = _$compile_;
+  }));
 
-    afterEach(function() {
-        angular.module('ui.config').value('ui.config', {}); // cleanup
-    });
+  afterEach(function () {
+    angular.module('ui.config').value('ui.config', {}); // cleanup
+  });
 
-    describe('compiling this directive', function () {
-        it('should throw an error if used against a non-textarea', function () {
-            function compile() {
-                $compile('<div ui-codemirror ng-model="foo"></div>')(scope);
-            }
-            expect(compile).toThrow();
-        });
+  describe('compiling this directive', function () {
+    it('should throw an error if used against a non-textarea', function () {
+      function compile() {
+        $compile('<div ui-codemirror ng-model="foo"></div>')(scope);
+      }
 
-        it('should not throw an error when used against a textarea', function () {
-            function compile() {
-                $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
-            }
-            expect(compile).not.toThrow();
-        });
-
-        it('should throw an error when no ngModel attribute defined', function () {
-            function compile() {
-                $compile('<textarea ui-codemirror></textarea>')(scope);
-            }
-            expect(compile).toThrow();
-        });
-
-        it('should watch the uiCodemirror attribute', function () {
-            spyOn(scope, '$watch');
-            $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
-            expect(scope.$watch).toHaveBeenCalled();
-        });
-
-        it('should include the passed options', function () {
-            spyOn(CodeMirror, 'fromTextArea');
-            $compile('<textarea ui-codemirror="{foo: \'bar\'}" ng-model="foo"></textarea>')(scope);
-            expect(CodeMirror.fromTextArea.mostRecentCall.args[1].foo).toEqual('bar');
-        });
-
-        it('should include the default options', function () {
-            spyOn(CodeMirror, 'fromTextArea');
-            $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
-            expect(CodeMirror.fromTextArea.mostRecentCall.args[1].bar).toEqual('baz');
-        });
+      expect(compile).toThrow();
     });
 
-    describe('when the model changes', function () {
-        it('should update the IDE', function () {
-            var element = $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
-            scope.foo = 'bar';
-            scope.$apply();
-            expect($.trim(element.siblings().text())).toBe(scope.foo);
-        });
+    it('should not throw an error when used against a textarea', function () {
+      function compile() {
+        $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
+      }
+
+      expect(compile).not.toThrow();
     });
 
-    describe('when the IDE changes', function () {
-        it('should update the model', function () {
-            var codemirror,
-                fromTextArea = CodeMirror.fromTextArea;
-            spyOn(CodeMirror, 'fromTextArea').andCallFake(function () {
-                codemirror = fromTextArea.apply(this, arguments);
-                return codemirror;
-            });
-            $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
-            scope.foo = 'bar';
-            scope.$apply();
-            var value = 'baz';
-            codemirror.setValue(value);
-            expect(scope.foo).toBe(value);
-        });
+    it('should throw an error when no ngModel attribute defined', function () {
+      function compile() {
+        $compile('<textarea ui-codemirror></textarea>')(scope);
+      }
+
+      expect(compile).toThrow();
     });
 
-    describe('when the model is undefined/null', function () {
-        it('should update the IDE with an empty string', function () {
-            var element = $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
-            scope.$apply();
-            expect(scope.foo).toBe(undefined);
-            expect($.trim(element.siblings().text())).toBe('');
-            scope.foo = null;
-            scope.$apply();
-            expect(scope.foo).toBe(null);
-            expect($.trim(element.siblings().text())).toBe('');
-        });
+    it('should watch the uiCodemirror attribute', function () {
+      spyOn(scope, '$watch');
+      $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
+      expect(scope.$watch).toHaveBeenCalled();
     });
 
-    describe('when the model is an object or an array', function () {
-        it('should throw an error', function () {
-            function compileWithObject() {
-                $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
-                scope.foo = {};
-                scope.$apply();
-            }
-
-            function compileWithArray() {
-                $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
-                scope.foo = [];
-                scope.$apply();
-            }
-
-            expect(compileWithObject).toThrow();
-            expect(compileWithArray).toThrow();
-        });
+    it('should include the passed options', function () {
+      spyOn(CodeMirror, 'fromTextArea');
+      $compile('<textarea ui-codemirror="{foo: \'bar\'}" ng-model="foo"></textarea>')(scope);
+      expect(CodeMirror.fromTextArea.mostRecentCall.args[1].foo).toEqual('bar');
     });
+
+    it('should include the default options', function () {
+      spyOn(CodeMirror, 'fromTextArea');
+      $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
+      expect(CodeMirror.fromTextArea.mostRecentCall.args[1].bar).toEqual('baz');
+    });
+  });
+
+  describe('when the model changes', function () {
+    it('should update the IDE', function () {
+      var element = $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
+      scope.foo = 'bar';
+      scope.$apply();
+      expect($.trim(element.siblings().text())).toBe(scope.foo);
+    });
+  });
+
+  describe('when the IDE changes', function () {
+    it('should update the model', function () {
+      var codemirror,
+        fromTextArea = CodeMirror.fromTextArea;
+      spyOn(CodeMirror, 'fromTextArea').andCallFake(function () {
+        codemirror = fromTextArea.apply(this, arguments);
+        return codemirror;
+      });
+      $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
+      scope.foo = 'bar';
+      scope.$apply();
+      var value = 'baz';
+      codemirror.setValue(value);
+      expect(scope.foo).toBe(value);
+    });
+  });
+
+  describe('when the model is undefined/null', function () {
+    it('should update the IDE with an empty string', function () {
+      var element = $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
+      scope.$apply();
+      expect(scope.foo).toBe(undefined);
+      expect($.trim(element.siblings().text())).toBe('');
+      scope.foo = null;
+      scope.$apply();
+      expect(scope.foo).toBe(null);
+      expect($.trim(element.siblings().text())).toBe('');
+    });
+  });
+
+  describe('when the model is an object or an array', function () {
+    it('should throw an error', function () {
+      function compileWithObject() {
+        $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
+        scope.foo = {};
+        scope.$apply();
+      }
+
+      function compileWithArray() {
+        $compile('<textarea ui-codemirror ng-model="foo"></textarea>')(scope);
+        scope.foo = [];
+        scope.$apply();
+      }
+
+      expect(compileWithObject).toThrow();
+      expect(compileWithArray).toThrow();
+    });
+  });
 });

--- a/modules/directives/currency/currency.js
+++ b/modules/directives/currency/currency.js
@@ -1,58 +1,57 @@
-
 /*
  Gives the ability to style currency based on its sign.
-*/
-  angular.module('ui.directives').directive('uiCurrency', ['ui.config','currencyFilter' , function(uiConfig, currencyFilter) {
-	  var options = {
-	      pos: 'ui-currency-pos',
-	      neg: 'ui-currency-neg',
-	      zero: 'ui-currency-zero'
-	};
-	if (uiConfig.currency) {
-		angular.extend(options, uiConfig.currency);
-	}
-    return {
-      restrict: 'EAC',
-      require: 'ngModel',
-      link: function(scope, element, attrs, controller) {
-        var opts, // instance-specific options
-          renderview, 
-          value;
-      
-        opts = angular.extend({}, options, scope.$eval(attrs.uiCurrency));
-        
-        renderview = function(viewvalue) {
-          var num;
-          num = viewvalue * 1;
-          if (num > 0) {
-            element.addClass(opts.pos);
-          } else {
-            element.removeClass(opts.pos);
-          }
-          if (num < 0) {
-            element.addClass(opts.neg);
-          } else {
-            element.removeClass(opts.neg);
-          }
-          if (num === 0) {
-            element.addClass(opts.zero);
-          } else {
-            element.removeClass(opts.zero);
-          }
-          if (viewvalue === '') {
-            element.text('');
-          } else {
-            element.text(currencyFilter(num, opts.symbol));
-          }
-          return true;
-        };
-        
-        controller.$render = function() {
-          value = controller.$viewValue;
-          element.val(value);
-          renderview(value);
-        };
-        
-      }
-    };
-  }]);
+ */
+angular.module('ui.directives').directive('uiCurrency', ['ui.config', 'currencyFilter' , function (uiConfig, currencyFilter) {
+  var options = {
+    pos: 'ui-currency-pos',
+    neg: 'ui-currency-neg',
+    zero: 'ui-currency-zero'
+  };
+  if (uiConfig.currency) {
+    angular.extend(options, uiConfig.currency);
+  }
+  return {
+    restrict: 'EAC',
+    require: 'ngModel',
+    link: function (scope, element, attrs, controller) {
+      var opts, // instance-specific options
+        renderview,
+        value;
+
+      opts = angular.extend({}, options, scope.$eval(attrs.uiCurrency));
+
+      renderview = function (viewvalue) {
+        var num;
+        num = viewvalue * 1;
+        if (num > 0) {
+          element.addClass(opts.pos);
+        } else {
+          element.removeClass(opts.pos);
+        }
+        if (num < 0) {
+          element.addClass(opts.neg);
+        } else {
+          element.removeClass(opts.neg);
+        }
+        if (num === 0) {
+          element.addClass(opts.zero);
+        } else {
+          element.removeClass(opts.zero);
+        }
+        if (viewvalue === '') {
+          element.text('');
+        } else {
+          element.text(currencyFilter(num, opts.symbol));
+        }
+        return true;
+      };
+
+      controller.$render = function () {
+        value = controller.$viewValue;
+        element.val(value);
+        renderview(value);
+      };
+
+    }
+  };
+}]);

--- a/modules/directives/currency/test/currencySpec.js
+++ b/modules/directives/currency/test/currencySpec.js
@@ -1,97 +1,97 @@
-  describe('uiCurrency', function() {
-    var scope;
-    scope = null,
+describe('uiCurrency', function () {
+  var scope;
+  scope = null,
     uiConfig = {};
-    beforeEach(module('ui'));
-    beforeEach(inject(function($rootScope) {
-      scope = $rootScope.$new();
-    }));
-    describe('use on a div element with two-way binding', function() {
-     it('should have ui-currency-pos style non-zero positive model number ', function() {
-        inject(function($compile) {
-          var element;
-          element = $compile("<div ui-currency ng-model='aNum'></div>")(scope);
-          scope.$apply(function() {
-            scope.aNum = 0.5123;
-          });
-          expect(element.text()).toEqual('$0.51');
-          expect(element.hasClass('ui-currency-pos')).toBeTruthy();
-          expect(element.hasClass('ui-currency-neg')).toBeFalsy();
-          expect(element.hasClass('ui-currency-zero')).toBeFalsy();
+  beforeEach(module('ui'));
+  beforeEach(inject(function ($rootScope) {
+    scope = $rootScope.$new();
+  }));
+  describe('use on a div element with two-way binding', function () {
+    it('should have ui-currency-pos style non-zero positive model number ', function () {
+      inject(function ($compile) {
+        var element;
+        element = $compile("<div ui-currency ng-model='aNum'></div>")(scope);
+        scope.$apply(function () {
+          scope.aNum = 0.5123;
         });
+        expect(element.text()).toEqual('$0.51');
+        expect(element.hasClass('ui-currency-pos')).toBeTruthy();
+        expect(element.hasClass('ui-currency-neg')).toBeFalsy();
+        expect(element.hasClass('ui-currency-zero')).toBeFalsy();
       });
-      it('should have ui-currency-neg style when negative model number', function() {
-        inject(function($compile) {
-          var element;
-          element = $compile("<div ui-currency ng-model='aNum'></div>")(scope);
-          scope.$apply(function() {
-            scope.aNum = -123;
-          });
-          expect(element.text()).toEqual('($123.00)');
-          expect(element.hasClass('ui-currency-pos')).toBeFalsy();
-          expect(element.hasClass('ui-currency-neg')).toBeTruthy();
-         });
-      });
-      it('should have ui-currency-zero style when zero model number', function() {
-        inject(function($compile) {
-          var element;
-          element = $compile("<div ui-currency ng-model='aNum'></div>")(scope);
-          scope.$apply(function() {
-            scope.aNum = 0;
-          });
-          expect(element.text()).toEqual('$0.00');
-          expect(element.hasClass('ui-currency-pos')).toBeFalsy();
-          expect(element.hasClass('ui-currency-neg')).toBeFalsy();
-          expect(element.hasClass('ui-currency-zero')).toBeTruthy();
-        });
-      });
-      it('should not have any ui-currency styles or a value at all when missing scope model value', function() {
-        inject(function($compile) {
-          var element;
-          element = $compile("<div ui-currency ng-model='aMissingNum'></div>")(scope);
-          expect(element.text()).toEqual('');
-          expect(element.hasClass('ui-currency-pos')).toBeFalsy();
-          expect(element.hasClass('ui-currency-neg')).toBeFalsy();
-          expect(element.hasClass('ui-currency-zero')).toBeFalsy();
-        });
-      });
-      it('should not have any ui-currency styles or a value at all when provided a non-numeric model value', function() {
-        inject(function($compile) {
-          var element;
-          element = $compile("<div ui-currency ng-model='aBadNum'></div>")(scope);
-          scope.$apply(function() {
-            scope.aBadNum = 'bad';
-          });
-          expect(element.text()).toEqual('');
-          expect(element.hasClass('ui-currency-pos')).toBeFalsy();
-          expect(element.hasClass('ui-currency-neg')).toBeFalsy();
-          expect(element.hasClass('ui-currency-zero')).toBeFalsy();
-        });
-      });
-      
-      it('should have user-defined positive style when provided in uiCurrency attr', function() {
-        inject(function($compile) {
-          var element;
-          element = $compile("<div ui-currency=\"{ pos:'pstyle' }\" ng-model='aNum'></div>")(scope);
-          scope.$apply(function() {
-            scope.aNum = 1;
-          });
-          expect(element.hasClass('pstyle')).toBeTruthy();
-        });
-      });
-      // Presumption is if above works then no need to test other cases, given the coverage in previous describe
     });
-    describe('use on a tag element', function() {
-      it('should have a defined element', function() {
-        inject(function($compile) {
-          var element;
-          element = $compile("<ui-currency ng-model='aNum'></ui-currency>")(scope);
-          scope.$apply(function() {
-            scope.aNum = 1;
-          });
-          expect(element).toBeDefined();
-          expect(element.text()).toEqual('$1.00');
+    it('should have ui-currency-neg style when negative model number', function () {
+      inject(function ($compile) {
+        var element;
+        element = $compile("<div ui-currency ng-model='aNum'></div>")(scope);
+        scope.$apply(function () {
+          scope.aNum = -123;
         });
+        expect(element.text()).toEqual('($123.00)');
+        expect(element.hasClass('ui-currency-pos')).toBeFalsy();
+        expect(element.hasClass('ui-currency-neg')).toBeTruthy();
+      });
+    });
+    it('should have ui-currency-zero style when zero model number', function () {
+      inject(function ($compile) {
+        var element;
+        element = $compile("<div ui-currency ng-model='aNum'></div>")(scope);
+        scope.$apply(function () {
+          scope.aNum = 0;
+        });
+        expect(element.text()).toEqual('$0.00');
+        expect(element.hasClass('ui-currency-pos')).toBeFalsy();
+        expect(element.hasClass('ui-currency-neg')).toBeFalsy();
+        expect(element.hasClass('ui-currency-zero')).toBeTruthy();
+      });
+    });
+    it('should not have any ui-currency styles or a value at all when missing scope model value', function () {
+      inject(function ($compile) {
+        var element;
+        element = $compile("<div ui-currency ng-model='aMissingNum'></div>")(scope);
+        expect(element.text()).toEqual('');
+        expect(element.hasClass('ui-currency-pos')).toBeFalsy();
+        expect(element.hasClass('ui-currency-neg')).toBeFalsy();
+        expect(element.hasClass('ui-currency-zero')).toBeFalsy();
+      });
+    });
+    it('should not have any ui-currency styles or a value at all when provided a non-numeric model value', function () {
+      inject(function ($compile) {
+        var element;
+        element = $compile("<div ui-currency ng-model='aBadNum'></div>")(scope);
+        scope.$apply(function () {
+          scope.aBadNum = 'bad';
+        });
+        expect(element.text()).toEqual('');
+        expect(element.hasClass('ui-currency-pos')).toBeFalsy();
+        expect(element.hasClass('ui-currency-neg')).toBeFalsy();
+        expect(element.hasClass('ui-currency-zero')).toBeFalsy();
+      });
+    });
+
+    it('should have user-defined positive style when provided in uiCurrency attr', function () {
+      inject(function ($compile) {
+        var element;
+        element = $compile("<div ui-currency=\"{ pos:'pstyle' }\" ng-model='aNum'></div>")(scope);
+        scope.$apply(function () {
+          scope.aNum = 1;
+        });
+        expect(element.hasClass('pstyle')).toBeTruthy();
+      });
+    });
+    // Presumption is if above works then no need to test other cases, given the coverage in previous describe
+  });
+  describe('use on a tag element', function () {
+    it('should have a defined element', function () {
+      inject(function ($compile) {
+        var element;
+        element = $compile("<ui-currency ng-model='aNum'></ui-currency>")(scope);
+        scope.$apply(function () {
+          scope.aNum = 1;
+        });
+        expect(element).toBeDefined();
+        expect(element.text()).toEqual('$1.00');
       });
     });
   });
+});

--- a/modules/directives/date/date.coffee
+++ b/modules/directives/date/date.coffee
@@ -1,17 +1,18 @@
-
 ###
  jQuery UI Datepicker plugin wrapper
  
  @param [ui-date] {object} Options to pass to $.fn.datepicker() merged onto ui.config
 ###
 angular.module('ui.directives').directive 'uiDate', ['ui.config', (uiConfig)->
-  options = {};
+  options = {}
+  ;
   if uiConfig.date?
     angular.extend(options, uiConfig.date)
 
   require: '?ngModel',
   link: (scope, element, attrs, controller)->
-    opts = angular.extend({}, options, scope.$eval(attrs.uiDate));
+    opts = angular.extend({}, options, scope.$eval(attrs.uiDate))
+    ;
 
     ### If we have a controller (i.e. ngModelController) then wire it up ###
     if controller?

--- a/modules/directives/date/test/dateSpec.coffee
+++ b/modules/directives/date/test/dateSpec.coffee
@@ -8,7 +8,6 @@ describe 'uiDate', ()->
   beforeEach module 'ui.directives'
 
   describe 'simple use on input element', ()->
-
     it 'should have a date picker attached', ()->
       inject ($compile, $rootScope)->
         element = $compile("<input ui-date></input>")($rootScope)
@@ -16,7 +15,7 @@ describe 'uiDate', ()->
 
     it 'should be able to get the date from the model', ()->
       inject ($compile, $rootScope)->
-        aDate = new Date(2010,12,1)
+        aDate = new Date(2010, 12, 1)
         element = $compile("<input ui-date ng-model='x'></input>")($rootScope)
         $rootScope.$apply ()->
           $rootScope.x = aDate
@@ -24,25 +23,25 @@ describe 'uiDate', ()->
 
     it 'should put the date in the model', ()->
       inject ($compile, $rootScope)->
-        aDate = new Date(2010,12,1)
+        aDate = new Date(2010, 12, 1)
         element = $compile("<input ui-date ng-model='x'></input>")($rootScope)
         selectDate(element, aDate)
         expect($rootScope.x).toEqual(aDate)
 
-   it 'should parse the date correctly from a string', ()->
-      inject ($compile, $rootScope)->
-        aDateString = "2012-07-30T17:59:16.395Z"
-        aDate = new Date(aDateString)
-        element = $compile("<input ui-date ng-model='x'></input>")($rootScope)
-        $rootScope.$apply ()->
-          $rootScope.x = aDateString
-        expect(element.datepicker('getDate').toDateString()).toEqual(aDate.toDateString())
-        expect(element.datepicker('getDate').toTimeString()).not.toEqual(aDate.toTimeString())
+  it 'should parse the date correctly from a string', ()->
+    inject ($compile, $rootScope)->
+      aDateString = "2012-07-30T17:59:16.395Z"
+      aDate = new Date(aDateString)
+      element = $compile("<input ui-date ng-model='x'></input>")($rootScope)
+      $rootScope.$apply ()->
+        $rootScope.x = aDateString
+      expect(element.datepicker('getDate').toDateString()).toEqual(aDate.toDateString())
+      expect(element.datepicker('getDate').toTimeString()).not.toEqual(aDate.toTimeString())
 
   describe 'use with ng-required directive', ()->
     it 'should be invalid initially', ()->
       inject ($compile, $rootScope)->
-        aDate = new Date(2010,12,1)
+        aDate = new Date(2010, 12, 1)
         element = $compile("<input ui-date ng-model='x' ng-required='true' ></input>")($rootScope)
         # Do an apply to ensure that the validation is run
         $rootScope.$apply()
@@ -50,7 +49,7 @@ describe 'uiDate', ()->
 
     it 'should be valid if model has been specified', ()->
       inject ($compile, $rootScope)->
-        aDate = new Date(2010,12,1)
+        aDate = new Date(2010, 12, 1)
         element = $compile("<input ui-date ng-model='x' ng-required='true' ></input>")($rootScope)
         $rootScope.$apply ()->
           $rootScope.x = aDate
@@ -58,13 +57,12 @@ describe 'uiDate', ()->
 
     it 'should be valid after the date has been picked', ()->
       inject ($compile, $rootScope)->
-        aDate = new Date(2010,12,1)
+        aDate = new Date(2010, 12, 1)
         element = $compile("<input ui-date ng-model='x' ng-required='true' ></input>")($rootScope)
         selectDate(element, aDate)
         expect(element.hasClass('ng-valid')).toBeTruthy()
 
   describe 'simple use on a div element', ()->
-
     it 'should have a date picker attached', ()->
       inject ($compile, $rootScope)->
         element = $compile("<div ui-date></div>")($rootScope)
@@ -72,7 +70,7 @@ describe 'uiDate', ()->
 
     it 'should be able to get the date from the model', ()->
       inject ($compile, $rootScope)->
-        aDate = new Date(2010,12,1)
+        aDate = new Date(2010, 12, 1)
         element = $compile("<div ui-date ng-model='x'></div>")($rootScope)
         $rootScope.$apply ()->
           $rootScope.x = aDate
@@ -80,7 +78,7 @@ describe 'uiDate', ()->
 
     it 'should put the date in the model', ()->
       inject ($compile, $rootScope)->
-        aDate = new Date(2010,12,1)
+        aDate = new Date(2010, 12, 1)
         element = $compile("<div ui-date ng-model='x'></div>")($rootScope)
         selectDate(element, aDate)
         expect($rootScope.x).toEqual(aDate)
@@ -88,7 +86,7 @@ describe 'uiDate', ()->
   describe 'use with ng-required directive', ()->
     it 'should be invalid initially', ()->
       inject ($compile, $rootScope)->
-        aDate = new Date(2010,12,1)
+        aDate = new Date(2010, 12, 1)
         element = $compile("<div ui-date ng-model='x' ng-required='true' ></div>")($rootScope)
         # Do an apply to ensure that the validation is run
         $rootScope.$apply()
@@ -96,7 +94,7 @@ describe 'uiDate', ()->
 
     it 'should be valid if model has been specified', ()->
       inject ($compile, $rootScope)->
-        aDate = new Date(2010,12,1)
+        aDate = new Date(2010, 12, 1)
         element = $compile("<div ui-date ng-model='x' ng-required='true' ></div>")($rootScope)
         $rootScope.$apply ()->
           $rootScope.x = aDate
@@ -104,7 +102,7 @@ describe 'uiDate', ()->
 
     it 'should be valid after the date has been picked', ()->
       inject ($compile, $rootScope)->
-        aDate = new Date(2010,12,1)
+        aDate = new Date(2010, 12, 1)
         element = $compile("<div ui-date ng-model='x' ng-required='true' ></div>")($rootScope)
         selectDate(element, aDate)
         expect(element.hasClass('ng-valid')).toBeTruthy()

--- a/modules/directives/event/event.js
+++ b/modules/directives/event/event.js
@@ -1,4 +1,3 @@
-
 /**
  * General-purpose Event binding. Bind any event not natively supported by Angular
  * Pass an object with keynames for events to ui-event
@@ -6,23 +5,23 @@
  *
  * @example <input ui-event="{ focus : 'counter++', blur : 'someCallback()' }">
  * @example <input ui-event="{ myCustomEvent : 'myEventHandler($event, $params)'}">
- * 
+ *
  * @param ui-event {string|object literal} The event to bind to as a string or a hash of events with their callbacks
  */
 angular.module('ui.directives').directive('uiEvent', ['$parse',
-function($parse) {
-	return function(scope, elm, attrs) {
-		var events = scope.$eval(attrs.uiEvent);
-		angular.forEach(events, function(uiEvent, eventName){
-      var fn = $parse(uiEvent);
-			elm.bind(eventName, function(evt) {
-        var params = Array.prototype.slice.call(arguments);
-        //Take out first paramater (event object);
-        params = params.splice(1);
-				scope.$apply(function() {
-          fn(scope, {$event: evt, $params: params})
+  function ($parse) {
+    return function (scope, elm, attrs) {
+      var events = scope.$eval(attrs.uiEvent);
+      angular.forEach(events, function (uiEvent, eventName) {
+        var fn = $parse(uiEvent);
+        elm.bind(eventName, function (evt) {
+          var params = Array.prototype.slice.call(arguments);
+          //Take out first paramater (event object);
+          params = params.splice(1);
+          scope.$apply(function () {
+            fn(scope, {$event: evt, $params: params})
+          });
         });
-			});
-		});
-	};
-}]);
+      });
+    };
+  }]);

--- a/modules/directives/event/test/eventSpec.js
+++ b/modules/directives/event/test/eventSpec.js
@@ -1,8 +1,8 @@
-describe('uiEvent', function() {
+describe('uiEvent', function () {
   var $scope, $rootScope, $compile
 
   beforeEach(module('ui.directives'));
-  beforeEach(inject(function(_$rootScope_, _$compile_) {
+  beforeEach(inject(function (_$rootScope_, _$compile_) {
     $compile = _$compile_;
     $rootScope = _$rootScope_;
   }));
@@ -11,10 +11,12 @@ describe('uiEvent', function() {
   function eventElement(scope, eventObject) {
     scope._uiEvent = eventObject || {};
     return $compile('<span ui-event="_uiEvent">')(scope);
-  };
+  }
 
-  describe('test', function() {
-    it('should work with dblclick event and assignment', function() {
+  ;
+
+  describe('test', function () {
+    it('should work with dblclick event and assignment', function () {
       $scope = $rootScope.$new();
       var elm = eventElement($scope, {'dblclick': 'dbl=true'});
       expect($scope.dbl).toBeUndefined();
@@ -22,10 +24,10 @@ describe('uiEvent', function() {
       expect($scope.dbl).toBe(true);
     });
 
-    it('should work with two events in one key a function', function() {
+    it('should work with two events in one key a function', function () {
       $scope = $rootScope.$new();
       $scope.counter = 0;
-      $scope.myfn = function() {
+      $scope.myfn = function () {
         $scope.counter++;
       };
       var elm = eventElement($scope, {'keyup mouseenter': 'myfn()'});
@@ -34,13 +36,13 @@ describe('uiEvent', function() {
       expect($scope.counter).toBe(2);
     });
 
-    it('should work work with multiple entries', function() {
+    it('should work work with multiple entries', function () {
       $scope = $rootScope.$new();
       $scope.amount = 5;
       var elm = eventElement($scope, {
         'click': 'amount=amount*2',
         'mouseenter': 'amount=amount*4',
-        'keyup': 'amount=amount*3', 
+        'keyup': 'amount=amount*3',
       });
       elm.trigger('click');
       expect($scope.amount).toBe(10);
@@ -50,9 +52,9 @@ describe('uiEvent', function() {
       expect($scope.amount).toBe(120);
     });
 
-    it('should allow passing of $event object', function() {
+    it('should allow passing of $event object', function () {
       $scope = $rootScope.$new();
-      $scope.clicky = function(par1, $event, par2) {
+      $scope.clicky = function (par1, $event, par2) {
         expect($event.foo).toBe('bar');
         expect(par1).toBe(1);
         expect(par2).toBe(2);
@@ -64,15 +66,15 @@ describe('uiEvent', function() {
       });
     });
 
-    it('should allow passing of $params object', function() {
+    it('should allow passing of $params object', function () {
       $scope = $rootScope.$new();
-      $scope.onStuff = function($event, $params) {
+      $scope.onStuff = function ($event, $params) {
         expect($event.type).toBe('stuff');
         expect($params[0]).toBe('foo');
         expect($params[1]).toBe('bar');
       };
       var elm = eventElement($scope, {'stuff': 'onStuff($event, $params)'});
-      $(elm).trigger('stuff', ['foo','bar']);
+      $(elm).trigger('stuff', ['foo', 'bar']);
     })
   });
 

--- a/modules/directives/if/if.js
+++ b/modules/directives/if/if.js
@@ -3,19 +3,19 @@
  * Originally created by @tigbro, for the @jquery-mobile-angular-adapter
  * https://github.com/tigbro/jquery-mobile-angular-adapter
  */
-angular.module('ui.directives').directive('uiIf', [function() {
+angular.module('ui.directives').directive('uiIf', [function () {
   return {
     transclude: 'element',
     priority: 1000,
     terminal: true,
     restrict: 'A',
-    compile: function(element, attr, linker) {
-      return function(scope, iterStartElement, attr) {
+    compile: function (element, attr, linker) {
+      return function (scope, iterStartElement, attr) {
         iterStartElement[0].doNotMove = true;
         var expression = attr.uiIf;
         var lastElement;
-        var lastScope; 
-        scope.$watch(expression, function(newValue) {
+        var lastScope;
+        scope.$watch(expression, function (newValue) {
           if (lastElement) {
             lastElement.remove();
             lastElement = null;
@@ -26,7 +26,7 @@ angular.module('ui.directives').directive('uiIf', [function() {
           }
           if (newValue) {
             lastScope = scope.$new();
-            linker(lastScope, function(clone) {
+            linker(lastScope, function (clone) {
               lastElement = clone;
               iterStartElement.after(clone);
             });

--- a/modules/directives/if/test/ifSpec.js
+++ b/modules/directives/if/test/ifSpec.js
@@ -1,29 +1,29 @@
-describe('ui-if', function() {
+describe('ui-if', function () {
   var scope, $compile, elm;
 
   beforeEach(module('ui.directives'));
-  beforeEach(inject(function($rootScope, _$compile_) {
+  beforeEach(inject(function ($rootScope, _$compile_) {
     scope = $rootScope.$new();
     $compile = _$compile_;
     elm = $('<div>');
   }));
 
   function makeIf(expr) {
-    elm.append( $compile('<div ui-if="'+expr+'"><div>Hi</div></div>')(scope) );
+    elm.append($compile('<div ui-if="' + expr + '"><div>Hi</div></div>')(scope));
     scope.$apply();
-  };
+  }
 
-  it('should immediately remove element if condition is false', function() {
+  it('should immediately remove element if condition is false', function () {
     makeIf('false');
     expect(elm.children().length).toBe(0);
   });
 
-  it('should leave the element if condition is true', function() {
+  it('should leave the element if condition is true', function () {
     makeIf('true');
     expect(elm.children().length).toBe(1);
   });
 
-  it('should create then remove the element if condition changes', function() {
+  it('should create then remove the element if condition changes', function () {
     scope.hello = true;
     makeIf('hello');
     expect(elm.children().length).toBe(1);
@@ -31,7 +31,7 @@ describe('ui-if', function() {
     expect(elm.children().length).toBe(0);
   });
 
-  it('should create a new scope', function() {
+  it('should create a new scope', function () {
     scope.$apply('value = true');
     elm.append($compile(
       '<div ui-if="value"><span ng-init="value=false"></span></div>'
@@ -40,12 +40,12 @@ describe('ui-if', function() {
     expect(elm.children('div').length).toBe(1);
   });
 
-  it('should play nice with other elements beside it', function() {
-    scope.values = [1,2,3,4];
+  it('should play nice with other elements beside it', function () {
+    scope.values = [1, 2, 3, 4];
     elm.append($compile(
-      '<div ng-repeat="i in values"></div>'+
-      '<div ui-if="values.length==4"></div>'+
-      '<div ng-repeat="i in values"></div>'
+      '<div ng-repeat="i in values"></div>' +
+        '<div ui-if="values.length==4"></div>' +
+        '<div ng-repeat="i in values"></div>'
     )(scope));
     scope.$apply();
     expect(elm.children().length).toBe(9);

--- a/modules/directives/jq/jq.js
+++ b/modules/directives/jq/jq.js
@@ -1,49 +1,48 @@
-
 /**
  * General-purpose jQuery wrapper. Simply pass the plugin name as the expression.
- * 
+ *
  * It is possible to specify a default set of parameters for each jQuery plugin.
  * Under the jq key, namespace each plugin by that which will be passed to ui-jq.
  * Unfortunately, at this time you can only pre-define the first parameter.
  * @example { jq : { datepicker : { showOn:'click' } } }
- * 
+ *
  * @param ui-jq {string} The $elm.[pluginName]() to call.
  * @param [ui-options] {mixed} Expression to be evaluated and passed as options to the function
- *   	Multiple parameters can be separated by commas
+ *     Multiple parameters can be separated by commas
  *    Set {ngChange:false} to disable passthrough support for change events ( since angular watches 'input' events, not 'change' events )
- * 
+ *
  * @example <input ui-jq="datepicker" ui-options="{showOn:'click'},secondParameter,thirdParameter">
  */
-angular.module('ui.directives').directive('uiJq', ['ui.config', function(uiConfig) {
-	return {
-		restrict: 'A',
-		compile: function(tElm, tAttrs) {  
-			if (!angular.isFunction(tElm[tAttrs.uiJq])) {
-				throw new Error('ui-jq: The "'+tAttrs.uiJq+'" function does not exist');
-				return;
-			}
-			var options = uiConfig['jq'] && uiConfig['jq'][tAttrs.uiJq];
-			return function (scope, elm, attrs) {
-				var linkOptions = [], ngChange = 'change';
+angular.module('ui.directives').directive('uiJq', ['ui.config', function (uiConfig) {
+  return {
+    restrict: 'A',
+    compile: function (tElm, tAttrs) {
+      if (!angular.isFunction(tElm[tAttrs.uiJq])) {
+        throw new Error('ui-jq: The "' + tAttrs.uiJq + '" function does not exist');
+        return;
+      }
+      var options = uiConfig['jq'] && uiConfig['jq'][tAttrs.uiJq];
+      return function (scope, elm, attrs) {
+        var linkOptions = [], ngChange = 'change';
 
-				if (attrs.uiOptions) {
-					linkOptions = scope.$eval('['+attrs.uiOptions+']');
-					if (angular.isObject(options) && angular.isObject(linkOptions[0])) {
-						linkOptions[0] = angular.extend(options, linkOptions[0]);
-					} 
-				} else if (options) {
-					linkOptions = [options]; 
-				}
-				if (attrs.ngModel && elm.is('select,input,textarea')) {
-					if (linkOptions && angular.isObject(linkOptions[0]) && linkOptions[0].ngChange !== undefined) {
-						ngChange = linkOptions[0].ngChange;
-					}
-					ngChange && elm.on(ngChange, function(){
-						elm.trigger('input');
-					});
-				}
-				elm[attrs.uiJq].apply(elm, linkOptions);
-			};
-		}
-	};
+        if (attrs.uiOptions) {
+          linkOptions = scope.$eval('[' + attrs.uiOptions + ']');
+          if (angular.isObject(options) && angular.isObject(linkOptions[0])) {
+            linkOptions[0] = angular.extend(options, linkOptions[0]);
+          }
+        } else if (options) {
+          linkOptions = [options];
+        }
+        if (attrs.ngModel && elm.is('select,input,textarea')) {
+          if (linkOptions && angular.isObject(linkOptions[0]) && linkOptions[0].ngChange !== undefined) {
+            ngChange = linkOptions[0].ngChange;
+          }
+          ngChange && elm.on(ngChange, function () {
+            elm.trigger('input');
+          });
+        }
+        elm[attrs.uiJq].apply(elm, linkOptions);
+      };
+    }
+  };
 }]);

--- a/modules/directives/jq/test/jqSpec.js
+++ b/modules/directives/jq/test/jqSpec.js
@@ -1,23 +1,24 @@
-describe('uiJq', function() {
+describe('uiJq', function () {
   var scope;
   scope = null;
   beforeEach(module('ui.directives'));
-  beforeEach(inject(function($rootScope) {
+  beforeEach(inject(function ($rootScope) {
     scope = $rootScope.$new();
   }));
-  describe('function or plugin isn\'t found', function() {
-    it('should throw an error', function() {
-      inject(function($compile) {
-        expect(function(){
+  describe('function or plugin isn\'t found', function () {
+    it('should throw an error', function () {
+      inject(function ($compile) {
+        expect(function () {
           $compile("<div ui-jq='failure'></div>")(scope);
         }).toThrow();
       });
     });
   });
-  describe('calling a jQuery element function', function() {
-    it('should just like, sort of work and junk', function() {
-      inject(function($compile) {
-        $.fn.success = function(){};
+  describe('calling a jQuery element function', function () {
+    it('should just like, sort of work and junk', function () {
+      inject(function ($compile) {
+        $.fn.success = function () {
+        };
         spyOn($.fn, 'success');
         $compile("<div ui-jq='success'></div>")(scope);
         expect($.fn.success).toHaveBeenCalled();

--- a/modules/directives/keypress/keypress.js
+++ b/modules/directives/keypress/keypress.js
@@ -1,15 +1,14 @@
-
 /**
  * Bind one or more handlers to particular keys or their combination
  * @param hash {mixed} keyBindings Can be an object or string where keybinding expression of keys or keys combinations and AngularJS Exspressions are set. Object syntax: "{ keys1: expression1 [, keys2: expression2 [ , ... ]]}". String syntax: ""expression1 on keys1 [ and expression2 on keys2 [ and ... ]]"". Expression is an AngularJS Expression, and key(s) are dash-separated combinations of keys and modifiers (one or many, if any. Order does not matter). Supported modifiers are 'ctrl', 'shift', 'alt' and key can be used either via its keyCode (13 for Return) or name. Named keys are 'backspace', 'tab', 'enter', 'esc', 'space', 'pageup', 'pagedown', 'end', 'home', 'left', 'up', 'right', 'down', 'insert', 'delete'.
  * @example <input ui-keypress="{enter:'x = 1', 'ctrl-shift-space':'foo()', 'shift-13':'bar()'}" /> <input ui-keypress="foo = 2 on ctrl-13 and bar('hello') on shift-esc" />
  **/
-angular.module('ui.directives').directive('uiKeypress', ['$parse', function($parse){
+angular.module('ui.directives').directive('uiKeypress', ['$parse', function ($parse) {
   return {
-    link: function(scope, elm, attrs) {
+    link: function (scope, elm, attrs) {
       var keysByCode = {
-        8:  'backspace',
-        9:  'tab',
+        8: 'backspace',
+        9: 'tab',
         13: 'enter',
         27: 'esc',
         32: 'space',
@@ -35,9 +34,9 @@ angular.module('ui.directives').directive('uiKeypress', ['$parse', function($par
       }
 
       // Prepare combinations for simple checking
-      angular.forEach(params, function(v, k) {
+      angular.forEach(params, function (v, k) {
         var combination = {};
-        if(paramsParsed) {
+        if (paramsParsed) {
           // An object passed
           combination.expression = $parse(v);
           combination.keys = k;
@@ -49,7 +48,7 @@ angular.module('ui.directives').directive('uiKeypress', ['$parse', function($par
         }
 
         keys = {};
-        angular.forEach(combination.keys.split('-'), function(value) {
+        angular.forEach(combination.keys.split('-'), function (value) {
           keys[value] = true;
         });
         combination.keys = keys;
@@ -57,29 +56,29 @@ angular.module('ui.directives').directive('uiKeypress', ['$parse', function($par
       });
 
       // Check only mathcing of pressed keys one of the conditions
-      elm.bind('keydown', function(event) {
+      elm.bind('keydown', function (event) {
         // No need to do that inside the cycle
-        var altPressed   = event.metaKey || event.altKey;
-        var ctrlPressed  = event.ctrlKey;
+        var altPressed = event.metaKey || event.altKey;
+        var ctrlPressed = event.ctrlKey;
         var shiftPressed = event.shiftKey;
 
         // Iterate over prepared combinations
-        angular.forEach(combinations, function(combination) {
+        angular.forEach(combinations, function (combination) {
 
           var mainKeyPressed = (combination.keys[keysByCode[event.keyCode]] || combination.keys[event.keyCode.toString()]) || false;
 
-          var altRequired   =  combination.keys.alt || false;
-          var ctrlRequired  =  combination.keys.ctrl || false;
-          var shiftRequired =  combination.keys.shift || false;
+          var altRequired = combination.keys.alt || false;
+          var ctrlRequired = combination.keys.ctrl || false;
+          var shiftRequired = combination.keys.shift || false;
 
-          if( mainKeyPressed &&
-              ( altRequired   == altPressed   ) &&
-              ( ctrlRequired  == ctrlPressed  ) &&
-              ( shiftRequired == shiftPressed )
+          if (mainKeyPressed &&
+            ( altRequired == altPressed   ) &&
+            ( ctrlRequired == ctrlPressed  ) &&
+            ( shiftRequired == shiftPressed )
             ) {
             // Run the function
-            scope.$apply(function(){
-              combination.expression(scope, { '$event' : event });
+            scope.$apply(function () {
+              combination.expression(scope, { '$event': event });
             });
           }
         });

--- a/modules/directives/keypress/test/keypressSpec.js
+++ b/modules/directives/keypress/test/keypressSpec.js
@@ -31,17 +31,17 @@ describe('uiKeypress', function () {
   describe('keypress with Object syntax', function () {
 
     it('should support single key press', function () {
-      createElement({'13':'event=true'}).trigger(createKeyEvent(13));
+      createElement({'13': 'event=true'}).trigger(createKeyEvent(13));
       expect($scope.event).toBe(true);
     });
 
     it('should support combined key press', function () {
-      createElement({'ctrl-shift-13':'event=true'}).trigger(createKeyEvent(13, false, true, true));
+      createElement({'ctrl-shift-13': 'event=true'}).trigger(createKeyEvent(13, false, true, true));
       expect($scope.event).toBe(true);
     });
 
     it('should support multiple key press definitions', function () {
-      var elm = createElement({'13':'event1=true', 'ctrl-shift-13':'event2=true'});
+      var elm = createElement({'13': 'event1=true', 'ctrl-shift-13': 'event2=true'});
 
       elm.trigger(createKeyEvent(13));
       expect($scope.event1).toBe(true);
@@ -52,7 +52,7 @@ describe('uiKeypress', function () {
 
     it('should support $event in expressions', function () {
 
-      var element = createElement({'esc':'cb($event)', '13':'event2=$event'});
+      var element = createElement({'esc': 'cb($event)', '13': 'event2=$event'});
 
       element.trigger(createKeyEvent(27));
       expect($scope.event1.keyCode).toBe(27);

--- a/modules/directives/map/map.js
+++ b/modules/directives/map/map.js
@@ -1,12 +1,12 @@
-(function() {
+(function () {
   var app = angular.module('ui.directives');
 
   //Setup map events from a google map object to trigger on a given element too,
   //then we just use ui-event to catch events from an element
   function bindMapEvents(scope, eventsStr, googleObject, element) {
-    angular.forEach(eventsStr.split(' '), function(eventName) {
-      var $event = { type: 'map-'+eventName };
-      google.maps.event.addListener(googleObject, eventName, function(evt) {
+    angular.forEach(eventsStr.split(' '), function (eventName) {
+      var $event = { type: 'map-' + eventName };
+      google.maps.event.addListener(googleObject, eventName, function (evt) {
         element.trigger(angular.extend({}, $event, evt));
         //We create an $apply if it isn't happening. we need better support for this
         //We don't want to use timeout because tons of these events fire at once,
@@ -16,108 +16,110 @@
     });
   }
 
-  app.directive('uiMap', 
-  ['ui.config', '$parse', function(uiConfig, $parse) {
+  app.directive('uiMap',
+    ['ui.config', '$parse', function (uiConfig, $parse) {
 
-    var mapEvents = 'bounds_changed center_changed click dblclick drag dragend '+
-    'dragstart heading_changed idle maptypeid_changed mousemove mouseout '+
-    'mouseover projection_changed resize rightclick tilesloaded tilt_changed '+
-    'zoom_changed';
-    var options = uiConfig.map || {};
-    
-    return {
-      restrict: 'A',
-      //doesn't work as E for unknown reason
-      link: function(scope, elm, attrs) {
-        var opts = angular.extend({}, options, scope.$eval(attrs.uiOptions));
-        var map = new google.maps.Map(elm[0], opts);
-        var model = $parse(attrs.uiMap);
+      var mapEvents = 'bounds_changed center_changed click dblclick drag dragend ' +
+        'dragstart heading_changed idle maptypeid_changed mousemove mouseout ' +
+        'mouseover projection_changed resize rightclick tilesloaded tilt_changed ' +
+        'zoom_changed';
+      var options = uiConfig.map || {};
 
-        //Set scope variable for the map
-        model.assign(scope, map); 
-
-        bindMapEvents(scope, mapEvents, map, elm);
-      }
-    };
-  }]);
-
-  app.directive('uiMapInfoWindow', 
-  ['ui.config', '$parse', '$compile', function(uiConfig, $parse, $compile) {
-
-    var infoWindowEvents = 'closeclick content_change domready '+
-    'position_changed zindex_changed';
-    var options = uiConfig.mapInfoWindow || {};
-
-    return {
-      link: function(scope, elm, attrs) {
-        var opts = angular.extend({}, options, scope.$eval(attrs.uiOptions));
-        opts.content = elm[0];
-        var model = $parse(attrs.uiMapInfoWindow);
-        var infoWindow = model(scope);
-
-        if (!infoWindow) {
-          infoWindow = new google.maps.InfoWindow(opts);
-          model.assign(scope, infoWindow);
-        }
-
-        bindMapEvents(scope, infoWindowEvents, infoWindow, elm);
-
-        /* The info window's contents dont' need to be on the dom anymore,
-         google maps has them stored.  So we just replace the infowindow element
-         with an empty div. (we don't just straight remove it from the dom because
-         straight removing things from the dom can mess up angular) */
-        elm.replaceWith('<div></div>');
-
-        //Decorate infoWindow.open to $compile contents before opening
-        var _open = infoWindow.open;
-        infoWindow.open = function open(a1,a2,a3,a4,a5,a6) {
-          $compile(elm.contents())(scope);
-          _open.call(infoWindow, a1,a2,a3,a4,a5,a6);
-        };
-      }
-    };
-  }]);
-
-  /* 
-  * Map overlay directives all work the same. Take map marker for example
-  * <ui-map-marker="myMarker"> will $watch 'myMarker' and each time it changes,
-  * it will hook up myMarker's events to the directive dom element.  Then
-  * ui-event will be able to catch all of myMarker's events. Super simple.
-  */
-  function mapOverlayDirective(directiveName, events) {
-    app.directive(directiveName, [function() {
       return {
         restrict: 'A',
-        link: function(scope, elm, attrs) {
-          scope.$watch(attrs[directiveName], function(newObject) {
+        //doesn't work as E for unknown reason
+        link: function (scope, elm, attrs) {
+          var opts = angular.extend({}, options, scope.$eval(attrs.uiOptions));
+          var map = new google.maps.Map(elm[0], opts);
+          var model = $parse(attrs.uiMap);
+
+          //Set scope variable for the map
+          model.assign(scope, map);
+
+          bindMapEvents(scope, mapEvents, map, elm);
+        }
+      };
+    }]);
+
+  app.directive('uiMapInfoWindow',
+    ['ui.config', '$parse', '$compile', function (uiConfig, $parse, $compile) {
+
+      var infoWindowEvents = 'closeclick content_change domready ' +
+        'position_changed zindex_changed';
+      var options = uiConfig.mapInfoWindow || {};
+
+      return {
+        link: function (scope, elm, attrs) {
+          var opts = angular.extend({}, options, scope.$eval(attrs.uiOptions));
+          opts.content = elm[0];
+          var model = $parse(attrs.uiMapInfoWindow);
+          var infoWindow = model(scope);
+
+          if (!infoWindow) {
+            infoWindow = new google.maps.InfoWindow(opts);
+            model.assign(scope, infoWindow);
+          }
+
+          bindMapEvents(scope, infoWindowEvents, infoWindow, elm);
+
+          /* The info window's contents dont' need to be on the dom anymore,
+           google maps has them stored.  So we just replace the infowindow element
+           with an empty div. (we don't just straight remove it from the dom because
+           straight removing things from the dom can mess up angular) */
+          elm.replaceWith('<div></div>');
+
+          //Decorate infoWindow.open to $compile contents before opening
+          var _open = infoWindow.open;
+          infoWindow.open = function open(a1, a2, a3, a4, a5, a6) {
+            $compile(elm.contents())(scope);
+            _open.call(infoWindow, a1, a2, a3, a4, a5, a6);
+          };
+        }
+      };
+    }]);
+
+  /* 
+   * Map overlay directives all work the same. Take map marker for example
+   * <ui-map-marker="myMarker"> will $watch 'myMarker' and each time it changes,
+   * it will hook up myMarker's events to the directive dom element.  Then
+   * ui-event will be able to catch all of myMarker's events. Super simple.
+   */
+  function mapOverlayDirective(directiveName, events) {
+    app.directive(directiveName, [function () {
+      return {
+        restrict: 'A',
+        link: function (scope, elm, attrs) {
+          scope.$watch(attrs[directiveName], function (newObject) {
             bindMapEvents(scope, events, newObject, elm);
           });
         }
       };
     }]);
-  };
+  }
 
-  mapOverlayDirective('uiMapMarker', 
-    'animation_changed click clickable_changed cursor_changed '+
-    'dblclick drag dragend draggable_changed dragstart flat_changed icon_changed '+
-    'mousedown mouseout mouseover mouseup position_changed rightclick '+
-    'shadow_changed shape_changed title_changed visible_changed zindex_changed');
-  
-  mapOverlayDirective('uiMapPolyline', 
+  ;
+
+  mapOverlayDirective('uiMapMarker',
+    'animation_changed click clickable_changed cursor_changed ' +
+      'dblclick drag dragend draggable_changed dragstart flat_changed icon_changed ' +
+      'mousedown mouseout mouseover mouseup position_changed rightclick ' +
+      'shadow_changed shape_changed title_changed visible_changed zindex_changed');
+
+  mapOverlayDirective('uiMapPolyline',
     'click dblclick mousedown mousemove mouseout mouseover mouseup rightclick');
-  
-  mapOverlayDirective('uiMapPolygon', 
+
+  mapOverlayDirective('uiMapPolygon',
     'click dblclick mousedown mousemove mouseout mouseover mouseup rightclick');
-  
-  mapOverlayDirective('uiMapRectangle', 
-    'bounds_changed click dblclick mousedown mousemove mouseout mouseover '+
-    'mouseup rightclick');
-  
-  mapOverlayDirective('uiMapCircle', 
-    'center_changed click dblclick mousedown mousemove '+
-    'mouseout mouseover mouseup radius_changed rightclick');
-  
-  mapOverlayDirective('uiMapGroundOverlay', 
+
+  mapOverlayDirective('uiMapRectangle',
+    'bounds_changed click dblclick mousedown mousemove mouseout mouseover ' +
+      'mouseup rightclick');
+
+  mapOverlayDirective('uiMapCircle',
+    'center_changed click dblclick mousedown mousemove ' +
+      'mouseout mouseover mouseup radius_changed rightclick');
+
+  mapOverlayDirective('uiMapGroundOverlay',
     'click dblclick');
 
 })();

--- a/modules/directives/map/test/mapSpec.js
+++ b/modules/directives/map/test/mapSpec.js
@@ -1,47 +1,47 @@
-describe('uiMap', function() {
+describe('uiMap', function () {
   var scope, $rootScope, $compile
 
   beforeEach(module('ui.directives'));
-  beforeEach(inject(function(_$compile_, _$rootScope_) {
+  beforeEach(inject(function (_$compile_, _$rootScope_) {
     $rootScope = _$rootScope_;
     $compile = _$compile_;
   }));
 
-  function createMap(options,events) {
+  function createMap(options, events) {
     scope.gmapOptions = options || {};
     scope.gmapEvents = events || {};
     console.log(angular.toJson(events));
-    $compile("<div ui-map='gmap' ui-options='gmapOptions'"+
+    $compile("<div ui-map='gmap' ui-options='gmapOptions'" +
       "' ui-event='gmapEvents'></div>")(scope);
-  };
+  }
 
   function createWindow(options, events, inner) {
     scope.gOptions = options || {};
     scope.gEvents = events || {};
     inner = inner || angular.element('');
-    var elm = angular.element("<div ui-map-info-window='ginfo' "+
+    var elm = angular.element("<div ui-map-info-window='ginfo' " +
       "ui-options='gOptions' ui-event='gEvents'></div>");
     elm.append(inner);
     $compile(elm)(scope);
   }
 
-  describe('test', function() {
-    beforeEach(function() {
+  describe('test', function () {
+    beforeEach(function () {
       scope = $rootScope.$new();
     });
 
-    it('should bind google map object to scope', function() {
+    it('should bind google map object to scope', function () {
       createMap();
       expect(scope.gmap).toBeTruthy();
     });
 
-    it('should create google map with given options', function() {
-      var center = new google.maps.LatLng(40,40);
+    it('should create google map with given options', function () {
+      var center = new google.maps.LatLng(40, 40);
       createMap({center: center});
       expect(scope.gmap.getCenter()).toBe(center);
     })
 
-    it('should pass events to the element as "map-eventname"', function() {
+    it('should pass events to the element as "map-eventname"', function () {
       scope.zoomy = false;
       scope.county = 0;
       createMap({}, {
@@ -57,17 +57,17 @@ describe('uiMap', function() {
     });
   });
 
-  describe('test infoWindow', function() {
-    beforeEach(function() {
+  describe('test infoWindow', function () {
+    beforeEach(function () {
       scope = $rootScope.$new();
     });
 
-    it('should bind info window to scope', function() {
+    it('should bind info window to scope', function () {
       createWindow();
       expect(scope.ginfo).toBeTruthy();
     });
 
-    it('should create info window with given options & content', function() {
+    it('should create info window with given options & content', function () {
       var content = $('<h1>Hi</h1>');
       createWindow({ zIndex: 5 }, {}, content);
       expect(scope.ginfo.getZIndex()).toBe(5);
@@ -75,22 +75,22 @@ describe('uiMap', function() {
         .toBe($('<div>').append(content).html());
     });
 
-    it('should $compile content and recognize scope changes', function() {
+    it('should $compile content and recognize scope changes', function () {
       var inner = $('<input ng-model="myVal">');
-      createWindow({},{},inner);
+      createWindow({}, {}, inner);
       createMap();
-      scope.$apply(function() {
+      scope.$apply(function () {
         scope.myVal = 'initial';
       });
       scope.ginfo.open(scope.gmap, scope.gmap.getCenter());
       expect(inner.val()).toBe('initial');
-      scope.$apply(function() {
+      scope.$apply(function () {
         scope.myVal = 'final';
       });
       expect(inner.val()).toBe('final');
     });
 
-    it('should recognize infowindow events in ui-event as "map-eventname"', function() {
+    it('should recognize infowindow events in ui-event as "map-eventname"', function () {
       createWindow({}, {
         'map-closeclick': 'closed = true'
       });

--- a/modules/directives/mask/mask.coffee
+++ b/modules/directives/mask/mask.coffee
@@ -1,4 +1,3 @@
-
 ###
  Attaches jquery-ui input mask onto input element
 ###
@@ -11,15 +10,15 @@ angular.module('ui.directives').directive 'uiMask', [()->
 
     ### We override the render method to run the jQuery mask plugin ###
     controller.$render = ()->
-      value = controller.$viewValue || '';
-      element.val(value);
-      element.mask($scope.uiMask);
+      value = controller.$viewValue || ''
+      element.val(value)
+      element.mask($scope.uiMask)
 
     ### Add a parser that extracts the masked value into the model but only if the mask is valid ###
     controller.$parsers.push (value)->
-       isValid = element.data('mask-isvalid')
-       controller.$setValidity('mask', isValid)
-       element.mask()
+      isValid = element.data('mask-isvalid')
+      controller.$setValidity('mask', isValid)
+      element.mask()
 
     ### When keyup, update the viewvalue ###
     element.bind 'keyup', ()->

--- a/modules/directives/mask/test/maskSpec.coffee
+++ b/modules/directives/mask/test/maskSpec.coffee
@@ -4,7 +4,7 @@ describe 'uiMask', ()->
   beforeEach module 'ui.directives'
 
   describe 'simple use on input element', ()->
-    
+
     # this test could prove nothing but will be expanded
     it 'should have a mask attached', ()->
       inject ($compile, $rootScope)->

--- a/modules/directives/modal/modal.js
+++ b/modules/directives/modal/modal.js
@@ -1,21 +1,21 @@
 angular.module('ui.directives')
-.directive('uiModal', ['$timeout', function($timeout) {
+  .directive('uiModal', ['$timeout', function ($timeout) {
   return {
     restrict: 'EAC',
     require: 'ngModel',
-    link: function(scope, elm, attrs, model) {
+    link: function (scope, elm, attrs, model) {
       //helper so you don't have to type class="modal hide"
       elm.addClass('modal hide');
-      scope.$watch(attrs.ngModel, function(value) {
+      scope.$watch(attrs.ngModel, function (value) {
         elm.modal(value && 'show' || 'hide');
       });
-      elm.on('show.ui', function() {
-        $timeout(function() {
+      elm.on('show.ui', function () {
+        $timeout(function () {
           model.$setViewValue(true);
         });
       });
-      elm.on('hide.ui', function() {
-        $timeout(function() {
+      elm.on('hide.ui', function () {
+        $timeout(function () {
           model.$setViewValue(false);
         });
       });

--- a/modules/directives/modal/test/modalSpec.js
+++ b/modules/directives/modal/test/modalSpec.js
@@ -1,9 +1,9 @@
-describe('modal', function() {
+describe('modal', function () {
   var elm, scope, $timeout;
 
   beforeEach(module('ui.directives'));
-  
-  beforeEach(inject(function($injector, $rootScope, $compile) {
+
+  beforeEach(inject(function ($injector, $rootScope, $compile) {
     scope = $rootScope;
     $timeout = $injector.get('$timeout');
     elm = $compile(
@@ -11,21 +11,21 @@ describe('modal', function() {
     )($rootScope);
   }));
 
-  it('should add "modal hide" class for you', function() {
+  it('should add "modal hide" class for you', function () {
     expect(elm.hasClass("modal hide")).toBe(true);
   });
-  
-  describe('model change', function() {
-    it('should open modal', function() {
-      scope.$apply(function() {
+
+  describe('model change', function () {
+    it('should open modal', function () {
+      scope.$apply(function () {
         scope.modalShown = true;
       });
       $timeout.flush();
       expect(elm.hasClass('in')).toBe(true);
     });
 
-    it('should close modal', function() {
-      scope.$apply(function() {
+    it('should close modal', function () {
+      scope.$apply(function () {
         scope.modalShown = false;
       });
       $timeout.flush();
@@ -33,238 +33,19 @@ describe('modal', function() {
     });
   });
 
-  describe('open/close events', function() {
-    it('should set model true when modal opens', function() {
+  describe('open/close events', function () {
+    it('should set model true when modal opens', function () {
       elm.modal('show');
       expect(scope.modalShown).toBeUndefined();
       $timeout.flush();
       expect(scope.modalShown).toBe(true);
     });
 
-    it('should set model false when modal closes', function() {
+    it('should set model false when modal closes', function () {
       elm.modal('hide');
       expect(scope.modalShown).toBeUndefined();
       $timeout.flush();
       expect(scope.modalShown).toBe(false);
     });
-  })
+  });
 });
-
-/* =========================================================
- * bootstrap-modal.js v2.0.4
- * http://twitter.github.com/bootstrap/javascript.html#modals
- * =========================================================
- * Copyright 2012 Twitter, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * ========================================================= */
-
-
-!function ($) {
-
-  "use strict"; // jshint ;_;
-
-
- /* MODAL CLASS DEFINITION
-  * ====================== */
-
-  var Modal = function (content, options) {
-    this.options = options
-    this.$element = $(content)
-      .delegate('[data-dismiss="modal"]', 'click.dismiss.modal', $.proxy(this.hide, this))
-  }
-
-  Modal.prototype = {
-
-      constructor: Modal
-
-    , toggle: function () {
-        return this[!this.isShown ? 'show' : 'hide']()
-      }
-
-    , show: function () {
-        var that = this
-          , e = $.Event('show')
-
-        this.$element.trigger(e)
-
-        if (this.isShown || e.isDefaultPrevented()) return
-
-        $('body').addClass('modal-open')
-
-        this.isShown = true
-
-        escape.call(this)
-        backdrop.call(this, function () {
-          var transition = $.support.transition && that.$element.hasClass('fade')
-
-          if (!that.$element.parent().length) {
-            that.$element.appendTo(document.body) //don't move modals dom position
-          }
-
-          that.$element
-            .show()
-
-          if (transition) {
-            that.$element[0].offsetWidth // force reflow
-          }
-
-          that.$element.addClass('in')
-
-          transition ?
-            that.$element.one($.support.transition.end, function () { that.$element.trigger('shown') }) :
-            that.$element.trigger('shown')
-
-        })
-      }
-
-    , hide: function (e) {
-        e && e.preventDefault()
-
-        var that = this
-
-        e = $.Event('hide')
-
-        this.$element.trigger(e)
-
-        if (!this.isShown || e.isDefaultPrevented()) return
-
-        this.isShown = false
-
-        $('body').removeClass('modal-open')
-
-        escape.call(this)
-
-        this.$element.removeClass('in')
-
-        $.support.transition && this.$element.hasClass('fade') ?
-          hideWithTransition.call(this) :
-          hideModal.call(this)
-      }
-
-  }
-
-
- /* MODAL PRIVATE METHODS
-  * ===================== */
-
-  function hideWithTransition() {
-    var that = this
-      , timeout = setTimeout(function () {
-          that.$element.off($.support.transition.end)
-          hideModal.call(that)
-        }, 500)
-
-    this.$element.one($.support.transition.end, function () {
-      clearTimeout(timeout)
-      hideModal.call(that)
-    })
-  }
-
-  function hideModal(that) {
-    this.$element
-      .hide()
-      .trigger('hidden')
-
-    backdrop.call(this)
-  }
-
-  function backdrop(callback) {
-    var that = this
-      , animate = this.$element.hasClass('fade') ? 'fade' : ''
-
-    if (this.isShown && this.options.backdrop) {
-      var doAnimate = $.support.transition && animate
-
-      this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />')
-        .appendTo(document.body)
-
-      if (this.options.backdrop != 'static') {
-        this.$backdrop.click($.proxy(this.hide, this))
-      }
-
-      if (doAnimate) this.$backdrop[0].offsetWidth // force reflow
-
-      this.$backdrop.addClass('in')
-
-      doAnimate ?
-        this.$backdrop.one($.support.transition.end, callback) :
-        callback()
-
-    } else if (!this.isShown && this.$backdrop) {
-      this.$backdrop.removeClass('in')
-
-      $.support.transition && this.$element.hasClass('fade')?
-        this.$backdrop.one($.support.transition.end, $.proxy(removeBackdrop, this)) :
-        removeBackdrop.call(this)
-
-    } else if (callback) {
-      callback()
-    }
-  }
-
-  function removeBackdrop() {
-    this.$backdrop.remove()
-    this.$backdrop = null
-  }
-
-  function escape() {
-    var that = this
-    if (this.isShown && this.options.keyboard) {
-      $(document).on('keyup.dismiss.modal', function ( e ) {
-        e.which == 27 && that.hide()
-      })
-    } else if (!this.isShown) {
-      $(document).off('keyup.dismiss.modal')
-    }
-  }
-
-
- /* MODAL PLUGIN DEFINITION
-  * ======================= */
-
-  $.fn.modal = function (option) {
-    return this.each(function () {
-      var $this = $(this)
-        , data = $this.data('modal')
-        , options = $.extend({}, $.fn.modal.defaults, $this.data(), typeof option == 'object' && option)
-      if (!data) $this.data('modal', (data = new Modal(this, options)))
-      if (typeof option == 'string') data[option]()
-      else if (options.show) data.show()
-    })
-  }
-
-  $.fn.modal.defaults = {
-      backdrop: true
-    , keyboard: true
-    , show: true
-  }
-
-  $.fn.modal.Constructor = Modal
-
-
- /* MODAL DATA-API
-  * ============== */
-
-  $(function () {
-    $('body').on('click.modal.data-api', '[data-toggle="modal"]', function ( e ) {
-      var $this = $(this), href
-        , $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
-        , option = $target.data('modal') ? 'toggle' : $.extend({}, $target.data(), $this.data())
-
-      e.preventDefault()
-      $target.modal(option)
-    })
-  })
-
-}(window.jQuery);

--- a/modules/directives/reset/reset.js
+++ b/modules/directives/reset/reset.js
@@ -3,8 +3,8 @@
  */
 angular.module('ui.directives').directive('uiReset', ['$parse', function ($parse) {
   return {
-    require:'ngModel',
-    link:function (scope, elm, attrs, ctrl) {
+    require: 'ngModel',
+    link: function (scope, elm, attrs, ctrl) {
       var aElement = angular.element('<a class="ui-reset" />');
       elm.wrap('<span class="ui-resetwrap" />').after(aElement);
 

--- a/modules/directives/reset/test/resetSpec.js
+++ b/modules/directives/reset/test/resetSpec.js
@@ -14,6 +14,7 @@ describe('uiReset', function () {
       function compile() {
         $compile('<input type="text" ui-reset/>')(scope);
       }
+
       expect(compile).toThrow();
     });
     it('should proper DOM structure', function () {

--- a/modules/directives/scrollfix/scrollfix.js
+++ b/modules/directives/scrollfix/scrollfix.js
@@ -5,35 +5,35 @@
  *   Takes 300 (absolute) or -300 or +300 (relative to detected)
  */
 angular.module('ui.directives').directive('uiScrollfix', ['$window', function ($window) {
-    'use strict';
-    return {
-        link: function (scope, elm, attrs) {
-            var top = elm.offset().top;
-            if (!attrs.uiScrollfix) {
-                attrs.uiScrollfix = top;
-            } else {
-                // chartAt is generally faster than indexOf: http://jsperf.com/indexof-vs-chartat
-                if (attrs.uiScrollfix.charAt(0) === '-') {
-                    attrs.uiScrollfix = top - attrs.uiScrollfix.substr(1);
-                } else if (attrs.uiScrollfix.charAt(0) === '+') {
-                    attrs.uiScrollfix = top + parseFloat(attrs.uiScrollfix.substr(1));
-                }
-            }
-            angular.element($window).on('scroll.ui-scrollfix', function () {
-                // if pageYOffset is defined use it, otherwise use other crap for IE
-                var offset;
-                if (angular.isDefined($window.pageYOffset)) {
-                    offset = $window.pageYOffset;
-                } else {
-                    var iebody = (document.compatMode && document.compatMode !== "BackCompat") ? document.documentElement : document.body;
-                    offset = iebody.scrollTop;
-                }
-                if (!elm.hasClass('ui-scrollfix') && offset > attrs.uiScrollfix) {
-                    elm.addClass('ui-scrollfix');
-                } else if (elm.hasClass('ui-scrollfix') && offset < attrs.uiScrollfix) {
-                    elm.removeClass('ui-scrollfix');
-                }
-            });
+  'use strict';
+  return {
+    link: function (scope, elm, attrs) {
+      var top = elm.offset().top;
+      if (!attrs.uiScrollfix) {
+        attrs.uiScrollfix = top;
+      } else {
+        // chartAt is generally faster than indexOf: http://jsperf.com/indexof-vs-chartat
+        if (attrs.uiScrollfix.charAt(0) === '-') {
+          attrs.uiScrollfix = top - attrs.uiScrollfix.substr(1);
+        } else if (attrs.uiScrollfix.charAt(0) === '+') {
+          attrs.uiScrollfix = top + parseFloat(attrs.uiScrollfix.substr(1));
         }
-    };
+      }
+      angular.element($window).on('scroll.ui-scrollfix', function () {
+        // if pageYOffset is defined use it, otherwise use other crap for IE
+        var offset;
+        if (angular.isDefined($window.pageYOffset)) {
+          offset = $window.pageYOffset;
+        } else {
+          var iebody = (document.compatMode && document.compatMode !== "BackCompat") ? document.documentElement : document.body;
+          offset = iebody.scrollTop;
+        }
+        if (!elm.hasClass('ui-scrollfix') && offset > attrs.uiScrollfix) {
+          elm.addClass('ui-scrollfix');
+        } else if (elm.hasClass('ui-scrollfix') && offset < attrs.uiScrollfix) {
+          elm.removeClass('ui-scrollfix');
+        }
+      });
+    }
+  };
 }]);

--- a/modules/directives/scrollfix/test/scrollfixSpec.js
+++ b/modules/directives/scrollfix/test/scrollfixSpec.js
@@ -1,39 +1,39 @@
 /*global describe, beforeEach, module, inject, it, spyOn, expect, $ */
 describe('uiScrollfix', function () {
-    'use strict';
+  'use strict';
 
-    var scope, $compile, $window;
-    beforeEach(module('ui.directives'));
-    beforeEach(inject(function (_$rootScope_, _$compile_, _$window_) {
-        scope = _$rootScope_.$new();
-        $compile = _$compile_;
-        $window = _$window_;
-    }));
+  var scope, $compile, $window;
+  beforeEach(module('ui.directives'));
+  beforeEach(inject(function (_$rootScope_, _$compile_, _$window_) {
+    scope = _$rootScope_.$new();
+    $compile = _$compile_;
+    $window = _$window_;
+  }));
 
-    describe('compiling this directive', function () {
-        it('should bind to window "scroll" event with a ui-scrollfix namespace', function () {
-            spyOn($.fn, 'on');
-            $compile('<div ui-scrollfix="100"></div>')(scope);
-            expect($.fn.on).toHaveBeenCalled();
-            expect($.fn.on.mostRecentCall.args[0]).toBe('scroll.ui-scrollfix');
-        });
+  describe('compiling this directive', function () {
+    it('should bind to window "scroll" event with a ui-scrollfix namespace', function () {
+      spyOn($.fn, 'on');
+      $compile('<div ui-scrollfix="100"></div>')(scope);
+      expect($.fn.on).toHaveBeenCalled();
+      expect($.fn.on.mostRecentCall.args[0]).toBe('scroll.ui-scrollfix');
     });
-    describe('scrolling the window', function () {
-        it('should add the ui-scrollfix class if the offset is greater than specified', function () {
-            var element = $compile('<div ui-scrollfix="-100"></div>')(scope);
-            $($window).trigger('scroll.ui-scrollfix');
-            expect(element.hasClass('ui-scrollfix')).toBe(true);
-        });
-        it('should remove the ui-scrollfix class if the offset is less than specified (using absolute coord)', function () {
-            var element = $compile('<div ui-scrollfix="100" class="ui-scrollfix"></div>')(scope);
-            $($window).trigger('scroll.ui-scrollfix');
-            expect(element.hasClass('ui-scrollfix')).toBe(false);
-
-        });
-        it('should remove the ui-scrollfix class if the offset is less than specified (using relative coord)', function () {
-            var element = $compile('<div ui-scrollfix="+100" class="ui-scrollfix"></div>')(scope);
-            $($window).trigger('scroll.ui-scrollfix');
-            expect(element.hasClass('ui-scrollfix')).toBe(false);
-        });
+  });
+  describe('scrolling the window', function () {
+    it('should add the ui-scrollfix class if the offset is greater than specified', function () {
+      var element = $compile('<div ui-scrollfix="-100"></div>')(scope);
+      $($window).trigger('scroll.ui-scrollfix');
+      expect(element.hasClass('ui-scrollfix')).toBe(true);
     });
+    it('should remove the ui-scrollfix class if the offset is less than specified (using absolute coord)', function () {
+      var element = $compile('<div ui-scrollfix="100" class="ui-scrollfix"></div>')(scope);
+      $($window).trigger('scroll.ui-scrollfix');
+      expect(element.hasClass('ui-scrollfix')).toBe(false);
+
+    });
+    it('should remove the ui-scrollfix class if the offset is less than specified (using relative coord)', function () {
+      var element = $compile('<div ui-scrollfix="+100" class="ui-scrollfix"></div>')(scope);
+      $($window).trigger('scroll.ui-scrollfix');
+      expect(element.hasClass('ui-scrollfix')).toBe(false);
+    });
+  });
 });

--- a/modules/directives/select2/select2.js
+++ b/modules/directives/select2/select2.js
@@ -1,104 +1,103 @@
-
 /**
  * Enhanced Select2 Dropmenus
  *
  * @AJAX Mode - When in this mode, your value will be an object (or array of objects) of the data used by Select2
- *   	This change is so that you do not have to do an additional query yourself on top of Select2's own query
+ *     This change is so that you do not have to do an additional query yourself on top of Select2's own query
  * @params [options] {object} The configuration options passed to $.fn.select2(). Refer to the documentation
  */
-angular.module('ui.directives').directive('uiSelect2', ['ui.config', '$http', function(uiConfig, $http){
-	var options = {};
-	if (uiConfig.select2) {
-		angular.extend(options, uiConfig.select2);
-	}
-	return {
-		require: '?ngModel',
-		compile: function(tElm, tAttrs) {
-			var watch,
-			repeatOption,
-			isSelect = tElm.is('select'),
-			isMultiple = (tAttrs.multiple !== undefined);
+angular.module('ui.directives').directive('uiSelect2', ['ui.config', '$http', function (uiConfig, $http) {
+  var options = {};
+  if (uiConfig.select2) {
+    angular.extend(options, uiConfig.select2);
+  }
+  return {
+    require: '?ngModel',
+    compile: function (tElm, tAttrs) {
+      var watch,
+        repeatOption,
+        isSelect = tElm.is('select'),
+        isMultiple = (tAttrs.multiple !== undefined);
 
-			// Enable watching of the options dataset if in use
-			if (tElm.is('select')) {
-				repeatOption = tElm.find('option[ng-repeat]');
-				if (repeatOption.length) {
-					watch = repeatOption.attr('ng-repeat').split(' ').pop();
-				}
-			}
+      // Enable watching of the options dataset if in use
+      if (tElm.is('select')) {
+        repeatOption = tElm.find('option[ng-repeat]');
+        if (repeatOption.length) {
+          watch = repeatOption.attr('ng-repeat').split(' ').pop();
+        }
+      }
 
-			return function(scope, elm, attrs, controller) {
-				// instance-specific options
-				var opts = angular.extend({}, options, scope.$eval(attrs.uiSelect2));
+      return function (scope, elm, attrs, controller) {
+        // instance-specific options
+        var opts = angular.extend({}, options, scope.$eval(attrs.uiSelect2));
 
-				if (isSelect) {
-					// Use <select multiple> instead
-					delete opts.multiple;
-					delete opts.initSelection;
-				} else if (isMultiple) {
-					opts.multiple = true;
-				}
+        if (isSelect) {
+          // Use <select multiple> instead
+          delete opts.multiple;
+          delete opts.initSelection;
+        } else if (isMultiple) {
+          opts.multiple = true;
+        }
 
-				if (controller) {
-					// Watch the model for programmatic changes
-					controller.$render = function() {
-						if (isSelect) {
-							elm.select2('val', controller.$modelValue);
-						} else {
-							if (isMultiple && !controller.$modelValue) {
-								elm.select2('data', []);
-							} else {
-								elm.select2('data', controller.$modelValue);
-							}
-						}
-					};
+        if (controller) {
+          // Watch the model for programmatic changes
+          controller.$render = function () {
+            if (isSelect) {
+              elm.select2('val', controller.$modelValue);
+            } else {
+              if (isMultiple && !controller.$modelValue) {
+                elm.select2('data', []);
+              } else {
+                elm.select2('data', controller.$modelValue);
+              }
+            }
+          };
 
 
-					// Watch the options dataset for changes
-					if (watch) {
-						scope.$watch(watch, function(newVal, oldVal, scope){
-							if (!newVal) return;
-							// Delayed so that the options have time to be rendered
-							setTimeout(function(){
-								elm.select2('val', controller.$viewValue);
-								// Refresh angular to remove the superfluous option
-								elm.trigger('change');
-							});
-						});
-					}
+          // Watch the options dataset for changes
+          if (watch) {
+            scope.$watch(watch, function (newVal, oldVal, scope) {
+              if (!newVal) return;
+              // Delayed so that the options have time to be rendered
+              setTimeout(function () {
+                elm.select2('val', controller.$viewValue);
+                // Refresh angular to remove the superfluous option
+                elm.trigger('change');
+              });
+            });
+          }
 
-					if (!isSelect) {
-						// Set the view and model value and update the angular template manually for the ajax/multiple select2.
-						elm.bind("change", function(){
-							scope.$apply(function(){
-								controller.$setViewValue(elm.select2('data'));
-							});
-						});
+          if (!isSelect) {
+            // Set the view and model value and update the angular template manually for the ajax/multiple select2.
+            elm.bind("change", function () {
+              scope.$apply(function () {
+                controller.$setViewValue(elm.select2('data'));
+              });
+            });
 
-						if (opts.initSelection) {
-							var initSelection = opts.initSelection;
-							opts.initSelection = function(element, callback) {
-								initSelection(element, function(value){
-									controller.$setViewValue(value);
-									callback(value);
-								});
-							}
-						}
-					}
-				}
+            if (opts.initSelection) {
+              var initSelection = opts.initSelection;
+              opts.initSelection = function (element, callback) {
+                initSelection(element, function (value) {
+                  controller.$setViewValue(value);
+                  callback(value);
+                });
+              }
+            }
+          }
+        }
 
-				attrs.$observe('disabled', function(value){
-					elm.select2(value && 'disable' || 'enable');
-				});
+        attrs.$observe('disabled', function (value) {
+          elm.select2(value && 'disable' || 'enable');
+        });
 
-				// Set initial value since Angular doesn't
-				elm.val(scope.$eval(attrs.ngModel));
+        // Set initial value since Angular doesn't
+        elm.val(scope.$eval(attrs.ngModel));
 
-				// Initialize the plugin late so that the injected DOM does not disrupt the template compiler
-				setTimeout(function(){
-					elm.select2(opts);
-				});
-			}
-		}
-	};
+        // Initialize the plugin late so that the injected DOM does not disrupt the template compiler
+        setTimeout(function () {
+          elm.select2(opts);
+        });
+      }
+    }
+  };
 }]);

--- a/modules/directives/showhide/showhide.js
+++ b/modules/directives/showhide/showhide.js
@@ -1,4 +1,3 @@
-
 /**
  * uiShow Directive
  *
@@ -7,16 +6,16 @@
  *
  * @param expression {boolean} evaluated expression to determine if the class should be added
  */
-angular.module('ui.directives').directive('uiShow', [function() {
-	return function(scope, elm, attrs) {
-		scope.$watch(attrs.uiShow, function(newVal, oldVal){
-			if (newVal) {
-				elm.addClass('ui-show');
-			} else {
-				elm.removeClass('ui-show');
-			}	
-		});
-	};
+angular.module('ui.directives').directive('uiShow', [function () {
+  return function (scope, elm, attrs) {
+    scope.$watch(attrs.uiShow, function (newVal, oldVal) {
+      if (newVal) {
+        elm.addClass('ui-show');
+      } else {
+        elm.removeClass('ui-show');
+      }
+    });
+  };
 }])
 
 /**
@@ -27,16 +26,16 @@ angular.module('ui.directives').directive('uiShow', [function() {
  *
  * @param expression {boolean} evaluated expression to determine if the class should be added
  */
-.directive('uiHide', [function() {
-	return function(scope, elm, attrs) {
-		scope.$watch(attrs.uiHide, function(newVal, oldVal){
-			if (newVal) {
-				elm.addClass('ui-hide');
-			} else {
-				elm.removeClass('ui-hide');
-			}
-		});
-	};
+  .directive('uiHide', [function () {
+  return function (scope, elm, attrs) {
+    scope.$watch(attrs.uiHide, function (newVal, oldVal) {
+      if (newVal) {
+        elm.addClass('ui-hide');
+      } else {
+        elm.removeClass('ui-hide');
+      }
+    });
+  };
 }])
 
 /**
@@ -48,14 +47,14 @@ angular.module('ui.directives').directive('uiShow', [function() {
  *
  * @param expression {boolean} evaluated expression to determine if the class should be added
  */
-.directive('uiToggle', [function() {
-	return function(scope, elm, attrs) {
-		scope.$watch(attrs.uiToggle, function(newVal, oldVal){
-			if (newVal) {
-				elm.removeClass('ui-hide').addClass('ui-show');
-			} else {
-				elm.removeClass('ui-show').addClass('ui-hide');
-			}
-		});
-	};
+  .directive('uiToggle', [function () {
+  return function (scope, elm, attrs) {
+    scope.$watch(attrs.uiToggle, function (newVal, oldVal) {
+      if (newVal) {
+        elm.removeClass('ui-hide').addClass('ui-show');
+      } else {
+        elm.removeClass('ui-show').addClass('ui-hide');
+      }
+    });
+  };
 }]);

--- a/modules/directives/sortable/sortable.coffee
+++ b/modules/directives/sortable/sortable.coffee
@@ -23,8 +23,8 @@ angular.module('ui.directives').directive 'uiSortable', ['ui.config', (uiConfig)
         end   = ui.item.index()
 
         # Reorder array and apply change to scope
-        ngModel.$modelValue.splice(end, 0, ngModel.$modelValue.splice(start, 1)[0]);
-        scope.$apply();
+        ngModel.$modelValue.splice(end, 0, ngModel.$modelValue.splice(start, 1)[0])
+        scope.$apply()
 
       # If user provided 'start' callback compose it with onStart function
       _start = opts.start

--- a/modules/directives/tinymce/test/tinymceSpec.js
+++ b/modules/directives/tinymce/test/tinymceSpec.js
@@ -1,51 +1,51 @@
 /*global describe, beforeEach, module, inject, it, spyOn, expect, $, angular, afterEach, runs, waits */
 describe('uiTinymce', function () {
-    'use strict';
+  'use strict';
 
-    var scope, $compile, element;
-    beforeEach(module('ui'));
-    beforeEach(function () {
-        // throw some garbage in the tinymce cfg to be sure it's getting thru to the directive
-        angular.module('ui.config').value('ui.config', {tinymce: {bar: 'baz'}});
+  var scope, $compile, element;
+  beforeEach(module('ui'));
+  beforeEach(function () {
+    // throw some garbage in the tinymce cfg to be sure it's getting thru to the directive
+    angular.module('ui.config').value('ui.config', {tinymce: {bar: 'baz'}});
+  });
+  beforeEach(inject(function (_$rootScope_, _$compile_) {
+    scope = _$rootScope_.$new();
+    $compile = _$compile_;
+  }));
+
+  afterEach(function () {
+    angular.module('ui.config').value('ui.config', {}); // cleanup
+  });
+
+  /**
+   * Asynchronously runs the compilation.
+   */
+  function compile() {
+    runs(function () {
+      element = $compile('<form><textarea name="foo" ui-tinymce="{foo: \'bar\'}" ng-model="foo"></textarea></form>')(scope);
     });
-    beforeEach(inject(function (_$rootScope_, _$compile_) {
-        scope = _$rootScope_.$new();
-        $compile = _$compile_;
-    }));
+    waits(1);
+  }
 
-    afterEach(function () {
-        angular.module('ui.config').value('ui.config', {}); // cleanup
+  describe('compiling this directive', function () {
+
+    it('should include the passed options', function () {
+      spyOn($.fn, 'tinymce');
+      compile();
+      runs(function () {
+        expect($.fn.tinymce).toHaveBeenCalled();
+        expect($.fn.tinymce.mostRecentCall.args[0].foo).toEqual('bar');
+      });
     });
 
-    /**
-     * Asynchronously runs the compilation.
-     */
-    function compile() {
-        runs(function () {
-            element = $compile('<form><textarea name="foo" ui-tinymce="{foo: \'bar\'}" ng-model="foo"></textarea></form>')(scope);
-        });
-        waits(1);
-    }
-
-    describe('compiling this directive', function () {
-
-        it('should include the passed options', function () {
-            spyOn($.fn, 'tinymce');
-            compile();
-            runs(function () {
-                expect($.fn.tinymce).toHaveBeenCalled();
-                expect($.fn.tinymce.mostRecentCall.args[0].foo).toEqual('bar');
-            });
-        });
-
-        it('should include the default options', function () {
-            spyOn($.fn, 'tinymce');
-            compile();
-            runs(function () {
-                expect($.fn.tinymce).toHaveBeenCalled();
-                expect($.fn.tinymce.mostRecentCall.args[0].bar).toEqual('baz');
-            });
-        });
+    it('should include the default options', function () {
+      spyOn($.fn, 'tinymce');
+      compile();
+      runs(function () {
+        expect($.fn.tinymce).toHaveBeenCalled();
+        expect($.fn.tinymce.mostRecentCall.args[0].bar).toEqual('baz');
+      });
     });
+  });
 
 });

--- a/modules/directives/tinymce/tinymce.js
+++ b/modules/directives/tinymce/tinymce.js
@@ -1,51 +1,50 @@
-
 /**
  * Binds a TinyMCE widget to <textarea> elements.
  */
-angular.module('ui.directives').directive('uiTinymce', ['ui.config', function(uiConfig){
-	uiConfig.tinymce = uiConfig.tinymce || {};
-	return {
-		require: 'ngModel',
-		link: function(scope, elm, attrs, ngModel) {
-			var expression,
-			  options = {
-				// Update model on button click
-				onchange_callback: function(inst) {
-					if (inst.isDirty()) {
-						inst.save();
-						ngModel.$setViewValue(elm.val());
-                           scope.$apply();
-					}
-				},
-				// Update model on keypress
-				handle_event_callback: function(e) {
-					if (this.isDirty()) {
-						this.save();
-						ngModel.$setViewValue(elm.val());
-                           scope.$apply();
-					}
-					return true; // Continue handling
-				},
-				// Update model when calling setContent (such as from the source editor popup)
-				setup : function(ed) {
-					ed.onSetContent.add(function(ed, o) {
-						if (ed.isDirty()) {
-							ed.save();
-							ngModel.$setViewValue(elm.val());
-							scope.$apply();
-						}
-					});
-				}
-			};
-			if (attrs.uiTinymce) {
-				expression = scope.$eval(attrs.uiTinymce);
-			} else {
-				expression = {};
-			}
-			angular.extend(options, uiConfig.tinymce, expression);
-			setTimeout(function(){
-				elm.tinymce(options);
-			});
-		}
-	};
+angular.module('ui.directives').directive('uiTinymce', ['ui.config', function (uiConfig) {
+  uiConfig.tinymce = uiConfig.tinymce || {};
+  return {
+    require: 'ngModel',
+    link: function (scope, elm, attrs, ngModel) {
+      var expression,
+        options = {
+          // Update model on button click
+          onchange_callback: function (inst) {
+            if (inst.isDirty()) {
+              inst.save();
+              ngModel.$setViewValue(elm.val());
+              scope.$apply();
+            }
+          },
+          // Update model on keypress
+          handle_event_callback: function (e) {
+            if (this.isDirty()) {
+              this.save();
+              ngModel.$setViewValue(elm.val());
+              scope.$apply();
+            }
+            return true; // Continue handling
+          },
+          // Update model when calling setContent (such as from the source editor popup)
+          setup: function (ed) {
+            ed.onSetContent.add(function (ed, o) {
+              if (ed.isDirty()) {
+                ed.save();
+                ngModel.$setViewValue(elm.val());
+                scope.$apply();
+              }
+            });
+          }
+        };
+      if (attrs.uiTinymce) {
+        expression = scope.$eval(attrs.uiTinymce);
+      } else {
+        expression = {};
+      }
+      angular.extend(options, uiConfig.tinymce, expression);
+      setTimeout(function () {
+        elm.tinymce(options);
+      });
+    }
+  };
 }]);

--- a/modules/directives/validate/test/validateSpec.js
+++ b/modules/directives/validate/test/validateSpec.js
@@ -15,11 +15,11 @@ describe('uiValidate', function ($compile) {
 
   beforeEach(module('ui'));
   beforeEach(inject(function ($rootScope, $compile) {
-    
+
     scope = $rootScope.$new();
     compileAndDigest = function (inputHtml, scope) {
       var inputElm = angular.element(inputHtml);
-      var formElm =  angular.element('<form name="form"></form>');
+      var formElm = angular.element('<form name="form"></form>');
       formElm.append(inputElm);
       $compile(formElm)(scope);
       scope.$digest();
@@ -35,7 +35,7 @@ describe('uiValidate', function ($compile) {
       scope.validate = trueValidator;
       compileAndDigest('<input name="input" ng-model="value" ui-validate="validate">', scope);
       expect(scope.form.input.$valid).toBeTruthy();
-      expect(scope.form.input.$error).toEqual({validator : false});
+      expect(scope.form.input.$error).toEqual({validator: false});
     }));
 
     it('should mark input as invalid if initial model is invalid', inject(function () {
@@ -43,7 +43,7 @@ describe('uiValidate', function ($compile) {
       scope.validate = falseValidator;
       compileAndDigest('<input name="input" ng-model="value" ui-validate="validate">', scope);
       expect(scope.form.input.$valid).toBeFalsy();
-      expect(scope.form.input.$error).toEqual({ validator : true });
+      expect(scope.form.input.$error).toEqual({ validator: true });
     }));
   });
 
@@ -82,9 +82,9 @@ describe('uiValidate', function ($compile) {
     });
   });
 
-  describe('multiple validators with custom keys', function(){
+  describe('multiple validators with custom keys', function () {
 
-    it('should support multiple validators with custom keys', function(){
+    it('should support multiple validators with custom keys', function () {
 
       scope.validate1 = trueValidator;
       scope.validate2 = falseValidator;

--- a/modules/directives/validate/validate.js
+++ b/modules/directives/validate/validate.js
@@ -15,9 +15,9 @@
 angular.module('ui.directives').directive('uiValidate', function () {
 
   return {
-    restrict:'A',
-    require:'ngModel',
-    link:function (scope, elm, attrs, ctrl) {
+    restrict: 'A',
+    require: 'ngModel',
+    link: function (scope, elm, attrs, ctrl) {
 
       var validateFn, validateExpr = attrs.uiValidate;
 
@@ -30,7 +30,7 @@ angular.module('ui.directives').directive('uiValidate', function () {
         validateExpr = { validator: validateExpr };
       }
 
-      angular.forEach(validateExpr, function(validatorFn, key){
+      angular.forEach(validateExpr, function (validatorFn, key) {
         validateFn = function (valueToValidate) {
           if (validatorFn(valueToValidate)) {
             ctrl.$setValidity(key, true);

--- a/modules/filters/highlight/highlight.js
+++ b/modules/filters/highlight/highlight.js
@@ -1,22 +1,21 @@
-
 /**
- * Wraps the 
+ * Wraps the
  * @param text {string} haystack to search through
  * @param search {string} needle to search for
  * @param [caseSensitive] {boolean} optional boolean to use case-sensitive searching
  */
-angular.module('ui.filters').filter('highlight', function() {
-	return function(text, search, caseSensitive) {
-		if (search || angular.isNumber(search)) {
-			text = text.toString();
-			search = search.toString();
-			if (caseSensitive) {
-				return text.split(search).join('<span class="ui-match">'+search+'</span>');
-			} else {
-				return text.replace(new RegExp(search, 'gi'), '<span class="ui-match">$&</span>');
-			}
-		} else {
-			return text;
-		}
-	};
+angular.module('ui.filters').filter('highlight', function () {
+  return function (text, search, caseSensitive) {
+    if (search || angular.isNumber(search)) {
+      text = text.toString();
+      search = search.toString();
+      if (caseSensitive) {
+        return text.split(search).join('<span class="ui-match">' + search + '</span>');
+      } else {
+        return text.replace(new RegExp(search, 'gi'), '<span class="ui-match">$&</span>');
+      }
+    } else {
+      return text;
+    }
+  };
 });

--- a/modules/filters/highlight/test/highlightSpec.js
+++ b/modules/filters/highlight/test/highlightSpec.js
@@ -1,48 +1,48 @@
-describe('highlight', function() {
+describe('highlight', function () {
   var highlightFilter, testPhrase = 'Prefix Highlight Suffix';
 
   beforeEach(module('ui.filters'));
-  beforeEach(inject(function($filter) {
+  beforeEach(inject(function ($filter) {
     highlightFilter = $filter('highlight');
   }));
-  describe('case insensitive', function(){
-    it('should highlight a matching phrase', function() {
+  describe('case insensitive', function () {
+    it('should highlight a matching phrase', function () {
       expect(highlightFilter(testPhrase, 'highlight')).toEqual('Prefix <span class="ui-match">Highlight</span> Suffix');
     });
-    it('should highlight nothing if no match found', function() {
+    it('should highlight nothing if no match found', function () {
       expect(highlightFilter(testPhrase, 'no match')).toEqual(testPhrase);
     });
-    it('should highlight nothing for the undefined filter', function() {
+    it('should highlight nothing for the undefined filter', function () {
       expect(highlightFilter(testPhrase, undefined)).toEqual(testPhrase);
     });
-    it('should work correctly for number filters', function() {
+    it('should work correctly for number filters', function () {
       expect(highlightFilter('3210123', 0)).toEqual('321<span class="ui-match">0</span>123');
     });
-    it('should work correctly for number text', function() {
+    it('should work correctly for number text', function () {
       expect(highlightFilter(3210123, '0')).toEqual('321<span class="ui-match">0</span>123');
     });
   });
-  describe('case sensitive', function(){
-    it('should highlight a matching phrase', function() {
+  describe('case sensitive', function () {
+    it('should highlight a matching phrase', function () {
       expect(highlightFilter(testPhrase, 'Highlight', true)).toEqual('Prefix <span class="ui-match">Highlight</span> Suffix');
     });
-    it('should highlight nothing if no match found', function() {
+    it('should highlight nothing if no match found', function () {
       expect(highlightFilter(testPhrase, 'no match', true)).toEqual(testPhrase);
     });
-    it('should highlight nothing for the undefined filter', function() {
+    it('should highlight nothing for the undefined filter', function () {
       expect(highlightFilter(testPhrase, undefined, true)).toEqual(testPhrase);
     });
-    it('should work correctly for number filters', function() {
+    it('should work correctly for number filters', function () {
       expect(highlightFilter('3210123', 0, true)).toEqual('321<span class="ui-match">0</span>123');
     });
-    it('should work correctly for number text', function() {
+    it('should work correctly for number text', function () {
       expect(highlightFilter(3210123, '0', true)).toEqual('321<span class="ui-match">0</span>123');
     });
-    it('should not highlight a phrase with different letter-casing', function() {
+    it('should not highlight a phrase with different letter-casing', function () {
       expect(highlightFilter(testPhrase, 'highlight', true)).toEqual(testPhrase);
     });
-  });  
-  it('should highlight nothing if empty filter string passed - issue #114', function() {
+  });
+  it('should highlight nothing if empty filter string passed - issue #114', function () {
     expect(highlightFilter(testPhrase, '')).toEqual(testPhrase);
   });
 });

--- a/modules/filters/inflector/inflector.js
+++ b/modules/filters/inflector/inflector.js
@@ -1,4 +1,3 @@
-
 /**
  * Converts variable-esque naming conventions to something presentational, capitalized words separated by space.
  * @param {String} value The value to be parsed and prettified.
@@ -7,37 +6,39 @@
  * @example {{ 'Here Is my_phoneNumber' | inflector:'humanize' }} => Here Is My Phone Number
  *          {{ 'Here Is my_phoneNumber' | inflector:'underscore' }} => here_is_my_phone_number
  *          {{ 'Here Is my_phoneNumber' | inflector:'variable' }} => hereIsMyPhoneNumber
- */ 
+ */
 angular.module('ui.filters').filter('inflector', function () {
-	function ucwords(text) {
-		return text.replace(/^([a-z])|\s+([a-z])/g, function ($1) {
-			return $1.toUpperCase();
-		});
-	}
-	function breakup(text, separator) {
-		return text.replace(/[A-Z]/g, function(match){
-			return separator + match;
-		});
-	}
-	var inflectors = {
-		humanize: function(value) {
-			return ucwords(breakup(value, ' ').split('_').join(' '));
-		},
-		underscore: function(value) {
-			return value.substr(0,1).toLowerCase() + breakup(value.substr(1), '_').toLowerCase().split(' ').join('_');
-		},
-		variable: function(value) {
-			value = value.substr(0,1).toLowerCase() + ucwords(value.split('_').join(' ')).substr(1).split(' ').join('');
-			return value;
-		}
-	};
+  function ucwords(text) {
+    return text.replace(/^([a-z])|\s+([a-z])/g, function ($1) {
+      return $1.toUpperCase();
+    });
+  }
 
-	return function (text, inflector, separator) {
-		if (inflector !== false && angular.isString(text)) {
-			inflector = inflector || 'humanize';
-			return inflectors[inflector](text);
-		} else {
-			return text;
-		}
-	};
+  function breakup(text, separator) {
+    return text.replace(/[A-Z]/g, function (match) {
+      return separator + match;
+    });
+  }
+
+  var inflectors = {
+    humanize: function (value) {
+      return ucwords(breakup(value, ' ').split('_').join(' '));
+    },
+    underscore: function (value) {
+      return value.substr(0, 1).toLowerCase() + breakup(value.substr(1), '_').toLowerCase().split(' ').join('_');
+    },
+    variable: function (value) {
+      value = value.substr(0, 1).toLowerCase() + ucwords(value.split('_').join(' ')).substr(1).split(' ').join('');
+      return value;
+    }
+  };
+
+  return function (text, inflector, separator) {
+    if (inflector !== false && angular.isString(text)) {
+      inflector = inflector || 'humanize';
+      return inflectors[inflector](text);
+    } else {
+      return text;
+    }
+  };
 });

--- a/modules/filters/inflector/test/inflectorSpec.js
+++ b/modules/filters/inflector/test/inflectorSpec.js
@@ -1,39 +1,39 @@
-describe('inflector', function() {
-	var inflectorFilter, testPhrase = 'here isMy_phone_number';
+describe('inflector', function () {
+  var inflectorFilter, testPhrase = 'here isMy_phone_number';
 
-	beforeEach(module('ui.filters'));
-	beforeEach(inject(function($filter) {
-		inflectorFilter = $filter('inflector');
-	}));
+  beforeEach(module('ui.filters'));
+  beforeEach(inject(function ($filter) {
+    inflectorFilter = $filter('inflector');
+  }));
 
-	describe('default', function() {
-		it('should default to humanize', function() {
-			expect(inflectorFilter(testPhrase)).toEqual('Here Is My Phone Number');
-		});
-    it('should fail gracefully for invalid input', function() {
+  describe('default', function () {
+    it('should default to humanize', function () {
+      expect(inflectorFilter(testPhrase)).toEqual('Here Is My Phone Number');
+    });
+    it('should fail gracefully for invalid input', function () {
       expect(inflectorFilter(undefined)).toBeUndefined();
     });
-    it('should do nothing for empty input', function() {
+    it('should do nothing for empty input', function () {
       expect(inflectorFilter('')).toEqual('');
     });
-	});
+  });
 
-	describe('humanize', function() {
-		it('should uppercase first letter and separate words with a space', function() {
-			expect(inflectorFilter(testPhrase, 'humanize')).toEqual('Here Is My Phone Number');
-		});
-	});
-	describe('underscore', function() {
-		it('should lowercase everything and separate words with an underscore', function() {
-			expect(inflectorFilter(testPhrase, 'underscore')).toEqual('here_is_my_phone_number');
-		});
-	});
-	describe('variable', function() {
-		it('should remove all separators and camelHump the phrase', function() {
-			expect(inflectorFilter(testPhrase, 'variable')).toEqual('hereIsMyPhoneNumber');
-		});
-    it('should do nothing if already formatted properly', function() {
+  describe('humanize', function () {
+    it('should uppercase first letter and separate words with a space', function () {
+      expect(inflectorFilter(testPhrase, 'humanize')).toEqual('Here Is My Phone Number');
+    });
+  });
+  describe('underscore', function () {
+    it('should lowercase everything and separate words with an underscore', function () {
+      expect(inflectorFilter(testPhrase, 'underscore')).toEqual('here_is_my_phone_number');
+    });
+  });
+  describe('variable', function () {
+    it('should remove all separators and camelHump the phrase', function () {
+      expect(inflectorFilter(testPhrase, 'variable')).toEqual('hereIsMyPhoneNumber');
+    });
+    it('should do nothing if already formatted properly', function () {
       expect(inflectorFilter("hereIsMyPhoneNumber", 'variable')).toEqual('hereIsMyPhoneNumber');
     });
-	});
+  });
 });

--- a/modules/filters/unique/test/uniqueSpec.js
+++ b/modules/filters/unique/test/uniqueSpec.js
@@ -1,49 +1,80 @@
-describe('unique', function() {
+describe('unique', function () {
   var uniqueFilter;
 
   beforeEach(module('ui.filters'));
-  beforeEach(inject(function($filter) {
+  beforeEach(inject(function ($filter) {
     uniqueFilter = $filter('unique');
   }));
 
   it('should return unique entries based on object equality', function () {
-    var arrayToFilter = [{key: 'value'}, {key: 'value2'}, {key: 'value'}];
-    expect(uniqueFilter(arrayToFilter)).toEqual([{key: 'value'}, {key: 'value2'}]);
+    var arrayToFilter = [
+      {key: 'value'},
+      {key: 'value2'},
+      {key: 'value'}
+    ];
+    expect(uniqueFilter(arrayToFilter)).toEqual([
+      {key: 'value'},
+      {key: 'value2'}
+    ]);
   });
 
   it('should return unique entries based on object equality for complex objects', function () {
-    var arrayToFilter = [{key: 'value', other: 'other1'}, {key: 'value2', other: 'other2'}, {other: 'other1', key: 'value'}];
-    expect(uniqueFilter(arrayToFilter)).toEqual([{key: 'value', other: 'other1'}, {key: 'value2', other: 'other2'}]);
+    var arrayToFilter = [
+      {key: 'value', other: 'other1'},
+      {key: 'value2', other: 'other2'},
+      {other: 'other1', key: 'value'}
+    ];
+    expect(uniqueFilter(arrayToFilter)).toEqual([
+      {key: 'value', other: 'other1'},
+      {key: 'value2', other: 'other2'}
+    ]);
   });
 
   it('should return unique entries based on the key provided', function () {
-    var arrayToFilter = [{key: 'value'}, {key: 'value2'}, {key: 'value'}];
-    expect(uniqueFilter(arrayToFilter, 'key')).toEqual([{key: 'value'}, {key: 'value2'}]);
+    var arrayToFilter = [
+      {key: 'value'},
+      {key: 'value2'},
+      {key: 'value'}
+    ];
+    expect(uniqueFilter(arrayToFilter, 'key')).toEqual([
+      {key: 'value'},
+      {key: 'value2'}
+    ]);
   });
 
   it('should return unique entries based on the key provided for complex objects', function () {
-    var arrayToFilter = [{key: 'value', other: 'other1'}, {key: 'value2', other: 'other2'}, {key: 'value', other: 'other3'}];
-    expect(uniqueFilter(arrayToFilter, 'key')).toEqual([{ key : 'value', other : 'other1' }, { key : 'value2', other : 'other2' }]);
+    var arrayToFilter = [
+      {key: 'value', other: 'other1'},
+      {key: 'value2', other: 'other2'},
+      {key: 'value', other: 'other3'}
+    ];
+    expect(uniqueFilter(arrayToFilter, 'key')).toEqual([
+      { key: 'value', other: 'other1' },
+      { key: 'value2', other: 'other2' }
+    ]);
   });
 
-  it('should return unique primitives in arrays', function() {
-    expect(uniqueFilter([1,2,1,3])).toEqual([1,2,3]);
+  it('should return unique primitives in arrays', function () {
+    expect(uniqueFilter([1, 2, 1, 3])).toEqual([1, 2, 3]);
   });
 
   it('should work correctly for arrays of mixed elements and object equality', function () {
-    expect(uniqueFilter([1,{key:'value'},1,{key:'value'},2,"string",3])).toEqual([1,{key:'value'},2,"string",3]);
+    expect(uniqueFilter([1, {key: 'value'}, 1, {key: 'value'}, 2, "string", 3])).toEqual([1, {key: 'value'}, 2, "string", 3]);
   });
 
   it('should work correctly for arrays of mixed elements and a key specified', function () {
-    expect(uniqueFilter([1,{key:'value'},1,{key:'value'},2,"string",3],'key')).toEqual([1,{key:'value'},2,"string",3]);
+    expect(uniqueFilter([1, {key: 'value'}, 1, {key: 'value'}, 2, "string", 3], 'key')).toEqual([1, {key: 'value'}, 2, "string", 3]);
   });
 
-  it('should return unmodified object if not array', function() {
-    expect(uniqueFilter('string','someKey')).toEqual('string');
+  it('should return unmodified object if not array', function () {
+    expect(uniqueFilter('string', 'someKey')).toEqual('string');
   });
 
-  it('should return unmodified array if provided key === false', function() {
-    var arrayToFilter = [{key: 'value1'}, {key: 'value2'}];
+  it('should return unmodified array if provided key === false', function () {
+    var arrayToFilter = [
+      {key: 'value1'},
+      {key: 'value2'}
+    ];
     expect(uniqueFilter(arrayToFilter, false)).toEqual(arrayToFilter);
   });
 

--- a/modules/filters/unique/unique.js
+++ b/modules/filters/unique/unique.js
@@ -1,23 +1,22 @@
-
 /**
  * Filters out all duplicate items from an array by checking the specified key
  * @param [key] {string} the name of the attribute of each object to compare for uniqueness
-	if the key is empty, the entire object will be compared
-	if the key === false then no filtering will be performed
+ if the key is empty, the entire object will be compared
+ if the key === false then no filtering will be performed
  * @return {array}
  */
-angular.module('ui.filters').filter('unique', function() {
+angular.module('ui.filters').filter('unique', function () {
 
-	return function(items, filterOn) {
+  return function (items, filterOn) {
 
-    if (filterOn===false){
+    if (filterOn === false) {
       return items;
     }
 
-		if ((filterOn || angular.isUndefined(filterOn))&& angular.isArray(items)) {
-			var hashCheck = {}, newItems = [];
+    if ((filterOn || angular.isUndefined(filterOn)) && angular.isArray(items)) {
+      var hashCheck = {}, newItems = [];
 
-      var extractValueToCompare = function(item) {
+      var extractValueToCompare = function (item) {
         if (angular.isObject(item) && angular.isString(filterOn)) {
           return item[filterOn];
         } else {
@@ -34,13 +33,13 @@ angular.module('ui.filters').filter('unique', function() {
             break;
           }
         }
-        if (!isDuplicate){
+        if (!isDuplicate) {
           newItems.push(item);
         }
 
       });
       items = newItems;
-		}
-		return items;
-	};
+    }
+    return items;
+  };
 });

--- a/templates/template.js
+++ b/templates/template.js
@@ -1,21 +1,21 @@
-angular.module('ui.directives').directive('uiTemplate', ['ui.config', function(uiConfig) {
+angular.module('ui.directives').directive('uiTemplate', ['ui.config', function (uiConfig) {
   var options = uiConfig.uiTemplate || {};
   return {
     restrict: 'EAC', // supports using directive as element, attribute and class
-    link: function(iScope, iElement, iAttrs, controller) {
+    link: function (iScope, iElement, iAttrs, controller) {
       var opts;
-      
+
       // opts is link element-specific options merged on top of global defaults. If you only extend the global default, then all instances would override each other
       opts = angular.extend({}, options, iAttrs.uiTemplate);
-      
+
       // your logic goes here
     }
   };
 }]);
 
 
-angular.module('ui.filters').filter('filterTmpl', ['ui.config', function(uiConfig) {
-	return function(value) {
-		return value;
-	};
+angular.module('ui.filters').filter('filterTmpl', ['ui.config', function (uiConfig) {
+  return function (value) {
+    return value;
+  };
 }]);

--- a/templates/test/templateSpec.js
+++ b/templates/test/templateSpec.js
@@ -1,7 +1,7 @@
 /*
  * sample unit testing for sample templates and implementations
-*/
-describe('uiTemplate', function() {
+ */
+describe('uiTemplate', function () {
 
   // declare these up here to be global to all tests
   var $rootScope, $compile;
@@ -11,45 +11,45 @@ describe('uiTemplate', function() {
 
   // inject in angular constructs. Injector knows about leading/trailing underscores and does the right thing
   // otherwise, you would need to inject these into each test
-  beforeEach(inject(function(_$rootScope_, _$compile_) {
-	  $rootScope = _$rootScope_;
+  beforeEach(inject(function (_$rootScope_, _$compile_) {
+    $rootScope = _$rootScope_;
     $compile = _$compile_;
   }));
-  
+
   // reset the ui.config after each test
-  afterEach(function(){
+  afterEach(function () {
     angular.module('ui.config').value('ui.config', {});
   });
-  
-  // optional grouping of tests
-  describe('filter', function() {
 
-	  // we're doing filter tests so globally define here for this subset of tests
-	  var $filter;
-	  beforeEach(inject(function(_$filter_) {
-	      $filter = _$filter_;
-	  }));
-	  
+  // optional grouping of tests
+  describe('filter', function () {
+
+    // we're doing filter tests so globally define here for this subset of tests
+    var $filter;
+    beforeEach(inject(function (_$filter_) {
+      $filter = _$filter_;
+    }));
+
     // very simple boilerplate setup of test for a custom filter
     var tmpl;
-    beforeEach(function() {
+    beforeEach(function () {
       tmpl = $filter('filterTmpl');
     });
 
-    it('should exist when provided', function() {
+    it('should exist when provided', function () {
       expect(tmpl).toBeDefined();
     });
-    
-    it('should return exactly what interesting thing the filter is doing to input', function() {
+
+    it('should return exactly what interesting thing the filter is doing to input', function () {
       expect(tmpl('text')).toEqual('text');
     });
 
   });
 
   // optional grouping of tests
-  describe('directive', function() {
+  describe('directive', function () {
     var element;
-    it('should create an element if using element-style', function() {
+    it('should create an element if using element-style', function () {
       var element = $compile('<ui-directive-tmpl ng-model="a"></ui-directive-tmpl>')($rootScope);
       expect(element).toBeDefined();
     });

--- a/test/lib/bootstrap/bootstrap-modal.js
+++ b/test/lib/bootstrap/bootstrap-modal.js
@@ -1,0 +1,213 @@
+
+/* =========================================================
+ * bootstrap-modal.js v2.0.4
+ * http://twitter.github.com/bootstrap/javascript.html#modals
+ * =========================================================
+ * Copyright 2012 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ========================================================= */
+
+
+!function ($) {
+
+  "use strict"; // jshint ;_;
+
+
+  /* MODAL CLASS DEFINITION
+   * ====================== */
+
+  var Modal = function (content, options) {
+    this.options = options;
+    this.$element = $(content)
+      .delegate('[data-dismiss="modal"]', 'click.dismiss.modal', $.proxy(this.hide, this))
+  };
+
+  Modal.prototype = {
+
+    constructor: Modal, toggle: function () {
+      return this[!this.isShown ? 'show' : 'hide']()
+    }, show: function () {
+      var that = this
+        , e = $.Event('show')
+
+      this.$element.trigger(e)
+
+      if (this.isShown || e.isDefaultPrevented()) return
+
+      $('body').addClass('modal-open')
+
+      this.isShown = true
+
+      escape.call(this)
+      backdrop.call(this, function () {
+        var transition = $.support.transition && that.$element.hasClass('fade')
+
+        if (!that.$element.parent().length) {
+          that.$element.appendTo(document.body) //don't move modals dom position
+        }
+
+        that.$element
+          .show()
+
+        if (transition) {
+          that.$element[0].offsetWidth // force reflow
+        }
+
+        that.$element.addClass('in')
+
+        transition ?
+          that.$element.one($.support.transition.end, function () {
+            that.$element.trigger('shown')
+          }) :
+          that.$element.trigger('shown')
+
+      })
+    }, hide: function (e) {
+      e && e.preventDefault()
+
+      var that = this
+
+      e = $.Event('hide')
+
+      this.$element.trigger(e)
+
+      if (!this.isShown || e.isDefaultPrevented()) return
+
+      this.isShown = false
+
+      $('body').removeClass('modal-open')
+
+      escape.call(this)
+
+      this.$element.removeClass('in')
+
+      $.support.transition && this.$element.hasClass('fade') ?
+        hideWithTransition.call(this) :
+        hideModal.call(this)
+    }
+
+  }
+
+
+  /* MODAL PRIVATE METHODS
+   * ===================== */
+
+  function hideWithTransition() {
+    var that = this
+      , timeout = setTimeout(function () {
+        that.$element.off($.support.transition.end)
+        hideModal.call(that)
+      }, 500)
+
+    this.$element.one($.support.transition.end, function () {
+      clearTimeout(timeout)
+      hideModal.call(that)
+    })
+  }
+
+  function hideModal(that) {
+    this.$element
+      .hide()
+      .trigger('hidden')
+
+    backdrop.call(this)
+  }
+
+  function backdrop(callback) {
+    var that = this
+      , animate = this.$element.hasClass('fade') ? 'fade' : ''
+
+    if (this.isShown && this.options.backdrop) {
+      var doAnimate = $.support.transition && animate
+
+      this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />')
+        .appendTo(document.body)
+
+      if (this.options.backdrop != 'static') {
+        this.$backdrop.click($.proxy(this.hide, this))
+      }
+
+      if (doAnimate) this.$backdrop[0].offsetWidth // force reflow
+
+      this.$backdrop.addClass('in')
+
+      doAnimate ?
+        this.$backdrop.one($.support.transition.end, callback) :
+        callback()
+
+    } else if (!this.isShown && this.$backdrop) {
+      this.$backdrop.removeClass('in')
+
+      $.support.transition && this.$element.hasClass('fade') ?
+        this.$backdrop.one($.support.transition.end, $.proxy(removeBackdrop, this)) :
+        removeBackdrop.call(this)
+
+    } else if (callback) {
+      callback()
+    }
+  }
+
+  function removeBackdrop() {
+    this.$backdrop.remove()
+    this.$backdrop = null
+  }
+
+  function escape() {
+    var that = this
+    if (this.isShown && this.options.keyboard) {
+      $(document).on('keyup.dismiss.modal', function (e) {
+        e.which == 27 && that.hide()
+      })
+    } else if (!this.isShown) {
+      $(document).off('keyup.dismiss.modal')
+    }
+  }
+
+
+  /* MODAL PLUGIN DEFINITION
+   * ======================= */
+
+  $.fn.modal = function (option) {
+    return this.each(function () {
+      var $this = $(this)
+        , data = $this.data('modal')
+        , options = $.extend({}, $.fn.modal.defaults, $this.data(), typeof option == 'object' && option)
+      if (!data) $this.data('modal', (data = new Modal(this, options)))
+      if (typeof option == 'string') data[option]()
+      else if (options.show) data.show()
+    })
+  }
+
+  $.fn.modal.defaults = {
+    backdrop: true, keyboard: true, show: true
+  }
+
+  $.fn.modal.Constructor = Modal
+
+
+  /* MODAL DATA-API
+   * ============== */
+
+  $(function () {
+    $('body').on('click.modal.data-api', '[data-toggle="modal"]', function (e) {
+      var $this = $(this), href
+        , $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
+        , option = $target.data('modal') ? 'toggle' : $.extend({}, $target.data(), $this.data())
+
+      e.preventDefault()
+      $target.modal(option)
+    })
+  })
+
+}(window.jQuery);

--- a/test/test-config.js
+++ b/test/test-config.js
@@ -18,6 +18,7 @@ files = [
   'test/lib/codemirror/codemirror.js',
   'test/lib/tinymce/jquery.tinymce.js',
   'test/lib/googlemaps/googlemaps.js',
+  'test/lib/bootstrap/bootstrap-modal.js',
   'common/module.js',
   'modules/*/*/*.js',
   'modules/*/*/test/*.js',


### PR DESCRIPTION
... out of modalSpec.js because it's ugly as sin.

Assuming we wanted to do this, I went ahead and did it.  I also corrected a couple places in the code where we didn't need semicolons.  Also some other slight formatting changes happened like a space after the word "function".  I can redo this if people hate that, but I like it.

All tests pass, so I think this should be OK.
