### PR TITLE
Added Calendar Directive

### DIFF
--- a/modules/directives/calendar/calendar.js
+++ b/modules/directives/calendar/calendar.js
@@ -36,13 +36,10 @@ angular.module('ui.directives').directive('uiCalendar',['ui.config', '$parse', f
             eventMouseover: function(event, jsEvent, view) {
             if (view.name !== 'agendaDay') {
               $(jsEvent.target).attr('title', event.title);
-<<<<<<< HEAD
              }
             },
-=======
             }
           },
->>>>>>> 41b260c1ef4461c32c957fd5e2a60e1a304c69e0
         
             // Calling the events from the scope through the ng-model binding attribute. 
             events: ngModel(scope)

--- a/modules/directives/calendar/calendar.js
+++ b/modules/directives/calendar/calendar.js
@@ -1,56 +1,65 @@
-/*
+    /*
 *  Implementation of JQuery FullCalendar 
 *  inspired by http://arshaw.com/fullcalendar/ 
 *  
-*  Basic Calendar Directive that takes in live events as the ng-model and then calls fullCalendar(options) to render the events correctly. 
+*  Basic Angular Calendar Directive that takes in live events as the ng-model and watches that event array for changes, to update the view accordingly. 
 *  
+* Authors
+*  @andyjoslin
 *  @joshkurz
 */
 
 angular.module('ui.directives').directive('uiCalendar',['ui.config', '$parse', function (uiConfig,$parse) {
 
-    uiConfig.uiCalendar = uiConfig.uiCalendar || {};              
-    //returns the calendar
+    uiConfig.uiCalendar = uiConfig.uiCalendar || {};    
+    //returns the calendar     
     return {
-      require: 'ngModel',
-      restrict : "A",
-      replace : true,
-      transclude : true,
-      scope: {
-        events: "=ngModel"
-      },
-       
-
-    link: function (scope, elm, $attrs, ngModel) {
-      var expression,
-        options = {
-          header: {
-            left: 'prev,next today',
-            center: 'title',
-            right: 'month,agendaWeek,agendaDay'
-          },
-
-          // add event name to title attribute on mouseover. 
-          eventMouseover: function(event, jsEvent, view) {
+        require: 'ngModel',
+        restrict: 'A',
+        scope: {
+          eventChanged: "=changed",
+          events: "=ngModel"
+        },
+        link: function(scope, elm, $attrs) {
+            var ngModel = $parse($attrs.ngModel);
+            //update method that is called on load and whenever the events array is changed. 
+            function update() {
+            //Default View Options
+            var expression,
+              options = {
+                header: {
+                left: 'prev,next today',
+                center: 'title',
+                right: 'month,agendaWeek,agendaDay'
+              },
+            // add event name to title attribute on mouseover. Would be nice if this was an angular popover. 
+            eventMouseover: function(event, jsEvent, view) {
             if (view.name !== 'agendaDay') {
-              (jsEvent.target).attr('title', event.title);
-            }
-          },
+              $(jsEvent.target).attr('title', event.title);
+             }
+            },
         
-          // Calling the events from the scope through the generic ng-model binding attribute. 
-          events: scope.events
-        };
-
-      if ($attrs.uiCalendar) {
-        expression = scope.$eval($attrs.uiCalendar);
-      } else {
-        expression = {};
-      }
-
-      angular.extend(options, uiConfig.uiCalendar, expression);
-      //use the options object to create the personalized calendar
-      elm.fullCalendar(options);
-    
-    }
-  };
+            // Calling the events from the scope through the ng-model binding attribute. 
+            events: ngModel(scope)
+            };          
+            //if attrs have been entered to directive, then create a relative expression. 
+            if ($attrs.uiCalendar)
+              expression = scope.$eval($attrs.uiCalendar);
+            else 
+              expression = {};
+              //extend the options to suite the custom directive.
+              angular.extend(options, uiConfig.uiCalendar, expression);
+              //call fullCalendar from an empty html tag, to keep angular happy.
+              elm.html('').fullCalendar(options);
+            }
+            //on load update call.
+            update();
+            //watch for changes to the eventChanged object passed into the directive, and update if changed. 
+            scope.$watch(function() {
+                return scope.eventChanged;
+            }, function() {
+                update();
+            },true);
+        }
+    };
 }]);

--- a/modules/directives/calendar/calendar.js
+++ b/modules/directives/calendar/calendar.js
@@ -38,8 +38,6 @@ angular.module('ui.directives').directive('uiCalendar',['ui.config', '$parse', f
               $(jsEvent.target).attr('title', event.title);
              }
             },
-            }
-          },
         
             // Calling the events from the scope through the ng-model binding attribute. 
             events: ngModel(scope)

--- a/modules/directives/calendar/test/calendarSpec.js
+++ b/modules/directives/calendar/test/calendarSpec.js
@@ -23,7 +23,31 @@ describe('uiCalendar', function () {
     //Creates a calendar with with two expressions height and weekends
     function createCalendar0(events) {
       scope.events = events || {};
-      $compile("<div ui-calendar='{height: 200, weekends: false}' ng-model='events'></div>")(scope);
+      scope.eventChanged = 0;
+
+      //Date Objects needed for event
+      var date = new Date();
+      var d = date.getDate();
+      var m = date.getMonth();
+      var y = date.getFullYear();
+
+      scope.addChild = function() {
+        scope.events.push({
+          title: 'Click for Google ' + scope.events.length,
+          start: new Date(y, m, 28),
+          end: new Date(y, m, 29),
+          url: 'http://google.com/'
+        });
+      
+        scope.eventChanged = scope.eventChanged + 1;
+      };
+
+      scope.remove = function(index) {
+        scope.events.splice(index,1);
+        scope.eventChanged = scope.eventChanged + 1;
+       };
+
+      $compile('<div ui-calendar="{height: 200, weekends: false}" ng-model="events" changed="eventChanged"></div>')(scope);
     }
 
     describe('compiling this directive and checking for the events', function () {
@@ -56,6 +80,7 @@ describe('uiCalendar', function () {
           allDay: false}
       ]; //End of Events Array
 
+
         //These tests pass because the scope.events object is created by the controller and passed into the directive, where the events are manipulated to fit the certain standards of the calendar.  
         it('should excpect to load 4 events to scope', function () {
             
@@ -85,6 +110,8 @@ describe('uiCalendar', function () {
 
             spyOn($.fn, 'fullCalendar');
             createCalendar0(events);
+          
+            //console.log('hello ' + $.fn.fullCalendar.mostRecentCall.args[0]);
             expect($.fn.fullCalendar.mostRecentCall.args[0].height).toEqual(200);
         
         });
@@ -94,6 +121,23 @@ describe('uiCalendar', function () {
             spyOn($.fn, 'fullCalendar');
             createCalendar0(events);
             expect($.fn.fullCalendar.mostRecentCall.args[0].weekends).toEqual(false);
+        });
+        //Test to make sure that when an event is added to the calendars updated with the new event.
+        it('should expect the scopes events to incease by 1', function () {
+
+            spyOn($.fn, 'fullCalendar');
+            createCalendar0(events);
+            scope.addChild();
+            scope.addChild();
+            expect(scope.events.length).toEqual(6);
+        });
+        //Test to make sure that when an event is removed the calendars events are updated.
+        it('should expect the local event array to stay the same', function () {
+
+            spyOn($.fn, 'fullCalendar');
+            createCalendar0(events);
+            scope.remove(0);
+            expect(scope.events.length).toEqual(5);
         });
 
        });


### PR DESCRIPTION
Added in a directive for fullcalendar.js created by https://github.com/arshaw/fullcalendar.

The first commit was a test run. I would only focus on the second commit. The third commit is just a file deletion. 

Changed the directive to pull in events from the ngModelController.
Got rid of the template.
Made the calendar more generic for the user.

Here is a working version of the directive. http://jsfiddle.net/FYn9z/4/
