### PR TITLE
Simplify custom build and make it work on win

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
     },
     concat: {
       build: {
-        src: ['<banner:meta.banner>', 'common/*.js', 'modules/*/*/*.js'],
+        src: ['<banner:meta.banner>'], 
         dest: '<%= builddir %>/<%= pkg.name %>.js'
       },
       ieshiv: {
@@ -73,12 +73,10 @@ module.exports = function (grunt) {
 
   grunt.registerTask('build', 'build all or some of the angular-ui modules', function () {
 
-    //if no modules given as args, go to default: build all
-    //else build custom modules into a custom folder
-    if (this.args.length > 0) {
+    var jsBuildFiles = grunt.config('concat.build.src');
+    var lessBuildFiles = grunt.config('recess.build.src');
 
-      var jsBuildFiles = [];
-      var lessBuildFiles = [];
+    if (this.args.length > 0) {
 
       this.args.forEach(function(moduleName) {
         var modulejs = grunt.file.expandFiles('modules/*/' + moduleName + '/*.js');
@@ -92,6 +90,10 @@ module.exports = function (grunt) {
       grunt.config('builddir', 'build/custom');
       grunt.config('concat.build.src', jsBuildFiles);
       grunt.config('recess.build.src', lessBuildFiles);
+
+    } else {
+      grunt.config('concat.build.src', jsBuildFiles.concat(['common/*.js', 'modules/*/*/*.js'])); 
+      grunt.config('recess.build.src', lessBuildFiles.concat(['common/**/*.less']));
     }
 
     grunt.task.run('concat min recess:build recess:min');

--- a/grunt.js
+++ b/grunt.js
@@ -11,10 +11,10 @@ module.exports = function (grunt) {
     builddir: 'build',
     pkg: '<json:package.json>',
     meta: {
-      banner: '/**\n' + ' * <%= pkg.description %>\n' + 
-      ' * @version v<%= pkg.version %> - ' + 
-      '<%= grunt.template.today("yyyy-mm-dd") %>\n' + 
-      ' * @link <%= pkg.homepage %>\n' + 
+      banner: '/**\n' + ' * <%= pkg.description %>\n' +
+      ' * @version v<%= pkg.version %> - ' +
+      '<%= grunt.template.today("yyyy-mm-dd") %>\n' +
+      ' * @link <%= pkg.homepage %>\n' +
       ' * @license MIT License, http://www.opensource.org/licenses/MIT\n' + ' */'
     },
     coffee: {
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
     },
     concat: {
       build: {
-        src: ['<banner:meta.banner>', 'common/*.js'],
+        src: ['<banner:meta.banner>', 'common/*.js', 'modules/*/*/*.js'],
         dest: '<%= builddir %>/<%= pkg.name %>.js'
       },
       ieshiv: {
@@ -68,57 +68,31 @@ module.exports = function (grunt) {
     }
   });
 
-  //Get all the available modules into an array
-  var modules = {};
-  grunt.file.recurse('modules', function(abspath, rootdir, subdir, filename) {
-    var moduleDir;
-    //If number of / is 1, we know it's first in depth. eg filters/inflector, not filters/inflector/test
-    if (subdir.split('/').length === 2) {
-      moduleDir = rootdir + '/' + subdir;
-      modules[subdir] = {
-        js: grunt.file.expand(moduleDir + '/*.js'),
-        less: grunt.file.expand(moduleDir + '/*.less')
-      };
-    }
-  });
-
   // Default task.
   grunt.registerTask('default', 'coffee build test');
 
-  grunt.registerTask('build', 'build all or some of the angular-ui modules', function() {
+  grunt.registerTask('build', 'build all or some of the angular-ui modules', function () {
 
-    var jsBuildFiles = grunt.config('concat.build.src');
-    var lessBuildFiles = grunt.config('recess.build.src');
+    //if no modules given as args, go to default: build all
+    //else build custom modules into a custom folder
+    if (this.args.length > 0) {
 
-    function addModuleFiles(module) {
-      module.js.forEach(function(file) {
-        jsBuildFiles.push(file);
-      });
-      module.less.forEach(function(file) {
-        lessBuildFiles.push(file);
-      });
-    }
+      var jsBuildFiles = [];
+      var lessBuildFiles = [];
 
-    if (this.args.length === 0) {
-      //if no modules given as args, go to default: build all
-      for (var moduleName in modules) {
-        if (modules.hasOwnProperty(moduleName)) {
-          addModuleFiles(modules[moduleName]);
-        }
-      }
-    } else {
-      //if args are found, build given modules & build to custom folder
-      grunt.config('builddir', 'build/custom');
       this.args.forEach(function(moduleName) {
-        if (modules[moduleName]) {
-          addModuleFiles(modules[moduleName]);
-        }
-      });
-    }
+        var modulejs = grunt.file.expandFiles('modules/*/' + moduleName + '/*.js');
+        var moduleless = grunt.file.expandFiles('modules/*/' + moduleName + '/stylesheets/*.less', 'modules/*/' + moduleName + '/*.less');
 
-    //Set config with our new file lists
-    grunt.config('concat.build.src', jsBuildFiles);
-    grunt.config('recess.build.src', lessBuildFiles);
+        jsBuildFiles = jsBuildFiles.concat(modulejs);
+        lessBuildFiles = lessBuildFiles.concat(moduleless);
+      });
+
+      //Set config with our new file lists
+      grunt.config('builddir', 'build/custom');
+      grunt.config('concat.build.src', jsBuildFiles);
+      grunt.config('recess.build.src', lessBuildFiles);
+    }
 
     grunt.task.run('concat min recess:build recess:min');
   });

--- a/grunt.js
+++ b/grunt.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
     },
     concat: {
       build: {
-        src: ['<banner:meta.banner>'], 
+        src: ['<banner:meta.banner>', 'common/*.js'], 
         dest: '<%= builddir %>/<%= pkg.name %>.js'
       },
       ieshiv: {
@@ -74,10 +74,11 @@ module.exports = function (grunt) {
   grunt.registerTask('build', 'build all or some of the angular-ui modules', function () {
 
     var jsBuildFiles = grunt.config('concat.build.src');
-    var lessBuildFiles = grunt.config('recess.build.src');
+    var lessBuildFiles = [];
 
     if (this.args.length > 0) {
 
+      lessBuildFiles.push(grunt.file.expandFiles('common/stylesheets/mixins.less'));
       this.args.forEach(function(moduleName) {
         var modulejs = grunt.file.expandFiles('modules/*/' + moduleName + '/*.js');
         var moduleless = grunt.file.expandFiles('modules/*/' + moduleName + '/stylesheets/*.less', 'modules/*/' + moduleName + '/*.less');
@@ -92,8 +93,8 @@ module.exports = function (grunt) {
       grunt.config('recess.build.src', lessBuildFiles);
 
     } else {
-      grunt.config('concat.build.src', jsBuildFiles.concat(['common/*.js', 'modules/*/*/*.js'])); 
-      grunt.config('recess.build.src', lessBuildFiles.concat(['common/**/*.less']));
+      grunt.config('concat.build.src', jsBuildFiles.concat(['modules/*/*/*.js'])); 
+      grunt.config('recess.build.src', lessBuildFiles.concat(grunt.config('recess.build.src')));
     }
 
     grunt.task.run('concat min recess:build recess:min');


### PR DESCRIPTION
Fixes the issue #180 and does several simplifications to the custom build started by Andy:
- code is smaller and OS-independent
- now custom build kicks-in only when arguments to the build are provided
- it is no longer necessary to specify type of a module, its name is enough: `grunt build:unique:reset:currency:highlight`

Would be great if you guys could test it on Linux / Mac. @ajoslin, would be great to have your feedback as I'm afraid that I might have simplified things too much :-)
