### PR TITLE
Initial version of the ui-input directive - RFC

### DIFF
--- a/modules/directives/input/input.js
+++ b/modules/directives/input/input.js
@@ -1,0 +1,101 @@
+angular.module('ui.directives', ['ui.config'])
+  .factory('InputHelper', ['$compile', '$http', '$templateCache', 'ui.config', function ($compile, $http, $templateCache, uiConfig) {
+
+  uiConfig.uiinput = uiConfig.uiinput || {};
+
+  var idUid = ['0', '0', '0'];
+  var nameUid = ['0', '0', '0'];
+
+  /*
+   Copyright (c) 2010-2012 Google, Inc. http://angularjs.org
+   This function is slightly modified version of the nextUid() function found in AngularJS code base
+   */
+  function nextUid(uid) {
+    var index = uid.length;
+    var digit;
+
+    while (index) {
+      index--;
+      digit = uid[index].charCodeAt(0);
+      if (digit == 57 /*'9'*/) {
+        uid[index] = 'A';
+        return uid.join('');
+      }
+      if (digit == 90  /*'Z'*/) {
+        uid[index] = '0';
+      } else {
+        uid[index] = String.fromCharCode(digit + 1);
+        return uid.join('');
+      }
+    }
+    uid.unshift('0');
+    return uid.join('');
+  }
+
+  /*
+   Copyright (c) 2010-2012 Google, Inc. http://angularjs.org
+   This function is slightly modified version of the snake_case() function found in AngularJS code base
+   */
+  function snake_case(name, separator) {
+    return name.replace(/[A-Z]/g, function (letter, pos) {
+      return (pos ? separator : '') + letter.toLowerCase();
+    });
+  }
+
+  var internalAttrs = ['family', 'kind', 'validation'];
+
+  return {
+    restrict:'E',
+    priority:10000,
+    terminal:true,
+    compile:function compile(tElement, tAttrs, transclude) {
+
+      var control = {
+        id:tAttrs.id || 'id' + nextUid(idUid)
+      };
+
+      return function (scope, element, attrs) {
+
+        var childScope = scope.$new();
+        var tplFamily = tAttrs.family || uiConfig.uiinput.family;
+        var tplKind = tAttrs.kind || uiConfig.uiinput.kind;
+
+        //infer a field type from template's tag name (can be one of ui-input, ui-select, ui-textarea)
+        var targetTagName = tElement[0].tagName.substring(3).toLowerCase();
+
+        $http.get(targetTagName + '.' + tplFamily + '.' + tplKind + '.html', {cache:$templateCache}).success(function (response) {
+
+          element.html(response);
+
+          var inputEl = angular.element(element.find(targetTagName)[0]);
+          angular.forEach(tAttrs, function (value, key) {
+            if (key.charAt(0) !== '$') {
+              if (key.indexOf('input') === 0) {
+                control[key.charAt(5).toLowerCase() + key.substr(6)] = value;
+              } else {
+                inputEl.attr(snake_case(key, '-'), value);
+              }
+            }
+          });
+
+          //prepare validation messages
+          control.validation = angular.extend({}, uiConfig.uiinput.validation, scope.$eval(tAttrs.validation));
+
+          //expose model to a field's template
+          childScope.$control = control;
+          $compile(element.contents())(childScope);
+          childScope.$field = inputEl.controller('ngModel');
+        });
+      };
+    }
+  };
+}])
+  .directive('uiInput', ['InputHelper', function (InputHelper) {
+  return InputHelper;
+}])
+  .directive('uiTextarea', ['InputHelper', function (InputHelper) {
+  return InputHelper;
+}])
+  .directive('uiSelect', ['InputHelper', function (InputHelper) {
+  return InputHelper;
+}]);

--- a/modules/directives/input/input.js
+++ b/modules/directives/input/input.js
@@ -1,3 +1,23 @@
+/*
+Test HTML
+
+
+      <section id="directives-input">
+        <div class="page-header">
+          <h1>Input</h1>
+        </div>
+        <div class="well">
+          <script type="text/ng-template" id="input">
+            <pre>{{$input.model|json}}</pre>
+            <input ng-transclude id="{{$input.id}}">
+            <label for="{{$input.id}}">{{$input.label}}</label>
+          </script>
+          <pre>Model: {{input|json}}</pre>
+          <ui-input src="'input'" label="Input" required ng-model="$parent.input"></ui-input>
+        </div>
+      </section>
+
+ */
 angular.module('ui.directives')
   .directive('uiInput', ['$compile', '$http', '$templateCache', 'ui.config', function ($compile, $http, $templateCache, uiConfig) {
 
@@ -51,30 +71,35 @@ angular.module('ui.directives')
     compile:function compile(tElement, tAttrs, transclude, uiForm) {
 
       var model = tAttrs.ngModel, input = {
-        id:tAttrs.id || 'input' + nextUid(idUid)
+        id:tAttrs.id || 'id' + nextUid(idUid)
       };
 
       return function (scope, element, attrs) {
 
-        //infer a field type from template's tag name (can be one of ui-input, ui-select, ui-textarea)
-        $http.get(scope.$eval(attrs.src), {cache:$templateCache}).success(function (response) {
+        scope.$watch(attrs.src, function(newVal, oldVal) {
+          if (!newVal)
+            return;
+          $http.get(newVal, {cache:$templateCache}).success(function (response) {
 
-          element.html(response);
+            element.html(response);
 
-          var inputEl = element.find('[ng-transclude]');
-          angular.forEach(tAttrs, function (value, key) {
-            if (key.charAt(0) !== '$' && ['src','uiInput'].indexOf(key) === -1) {
-              inputEl.attr(snake_case(key, '-'), value);
-            }
+            var inputEl = element.find('[ng-transclude]');
+            angular.forEach(tAttrs, function (value, key) {
+              if (key.charAt(0) !== '$' && ['src','uiInput', 'id'].indexOf(key) === -1) {
+                inputEl.attr(snake_case(key, '-'), value);
+                input[key] = value;
+              }
+            });
+            inputEl.removeAttr('ng-transclude');
+
+            //prepare validation messages
+            input.validation = angular.extend({}, uiConfig.input.validation, scope.$eval(tAttrs.validation));
+
+            //expose model to a field's template
+            scope.$input = input;
+            $compile(element.contents())(scope);
+            scope.$field = inputEl.controller('ngModel');
           });
-
-          //prepare validation messages
-          input.validation = angular.extend({}, uiConfig.input.validation, scope.$eval(tAttrs.validation));
-
-          //expose model to a field's template
-          scope.$input = input;
-          $compile(element.contents())(scope);
-          scope.$field = inputEl.controller('ngModel');
         });
       };
     }


### PR DESCRIPTION
This is initial version of the code for the new ui-input family of directives (ui-input, ui-select, ui-textarea) as described in the issue #189.

You can see it in action in this plunk: http://embed.plnkr.co/TT1t1p

From the last discussion on the mailing list several things have changed:
- validation messages now can be configured on a module level
- familly and kind of a input's template can be configured on a module level
- select and textarea are supported

There are still plenty of things that should be discussed done (no tests for the moment!) but I feel like this is a good starting point. I've started to use it a bit already and it is extremely powerful, it really makes it possible to write forms with the consistent look & fell - fast!

Let's discuss the concepts behind and the implementation itself!
