### PR TITLE
Adding TrevDev's new valid-expression validation directive

### DIFF
--- a/modules/directives/validexp/validexp.js
+++ b/modules/directives/validexp/validexp.js
@@ -1,0 +1,39 @@
+/**
+ * Validation Expressions with support for watch
+ * (might get merged into ui-validate)
+ *
+ * @author TrevDev
+ * @type {String}
+ * @example ui-validexp="{ exp:'$value > valA', watch: 'valA' }"
+ */
+angular.module('ui.directives').directive('uiValidexp', function () {
+  return {
+    restrict: 'A',
+    require: 'ngModel',
+    link: function (scope, elm, attrs, ctrl) {
+
+      var myObj = scope.$eval(attrs.uiValidexp);
+
+      var oldValue;
+      var validateExpValidator = function (value) {
+        oldValue = value;
+        if (scope.$eval(myObj.exp, { '$value': value })) {
+          ctrl.$setValidity('validexp', true);
+          return value;
+        } else {
+          ctrl.$setValidity('validexp', false);
+          return undefined;
+        }
+      };
+
+      ctrl.$parsers.push(validateExpValidator);
+      ctrl.$formatters.push(validateExpValidator);
+
+      if (myObj.watch) {
+        scope.$watch(myObj.watch, function () {
+          validateExpValidator(oldValue);
+        });
+      }
+    }
+  };
+});


### PR DESCRIPTION
WIP! Do not merge, this is for review and consideration.

Note that it may be worth while to just add support for a watch property to `ui-validate` instead of implementing this. Perhaps a second directive called `ui-validate-watch` that depends on `ui-validate` and imports the controller?

Theoretically, the 'expression' could be the functions passed to ui-validate.
