### PR TITLE
Support for dates of the format "1922-03-08T00:00:00.000Z" in datepicker

### DIFF
--- a/modules/directives/date/date.js
+++ b/modules/directives/date/date.js
@@ -46,9 +46,12 @@ angular.module('ui.directives').directive('uiDate', ['ui.config', function (uiCo
           controller.$render = function () {
             var date = controller.$viewValue;
             element.datepicker("setDate", date);
-            // Update the model if we received a string
             if (angular.isString(date)) {
+              element.datepicker("setDate", new Date(date));
+              // Update the model if we received a string
               controller.$setViewValue(element.datepicker("getDate"));
+            } else {
+              element.datepicker("setDate", date);
             }
           };
         }

--- a/modules/directives/date/test/dateSpec.js
+++ b/modules/directives/date/test/dateSpec.js
@@ -109,6 +109,18 @@ describe('uiDate', function() {
         expect(element.datepicker('getDate')).toEqual(aDate);
       });
     });
+    it('should be able to use an ISOdate', function() {
+      inject(function($compile, $rootScope) {
+          var aDate, element, dateStr;
+          dateStr = "1922-03-08T00:00:00.000Z";
+          aDate = new Date(dateStr);
+          element = $compile("<div ui-date ng-model='x'></div>")($rootScope);
+          $rootScope.$apply(function() {
+              $rootScope.x = dateStr;
+          });
+          expect(element.datepicker('getDate')).toEqual(aDate);
+      });
+    });
     it('should put the date in the model', function() {
       inject(function($compile, $rootScope) {
         var aDate, element;


### PR DESCRIPTION
This solves a problem I was having where dates from Mongo get wrongly interpreted.  I am a bit of a beginner, so I apologise if I have done anything wrong.
