### PR TITLE
Added ui-date-format directive to be used in conjunction with date directive.

### DIFF
--- a/modules/directives/date/date.js
+++ b/modules/directives/date/date.js
@@ -5,7 +5,9 @@
  @param [ui-date] {object} Options to pass to $.fn.datepicker() merged onto ui.config
  */
 
-angular.module('ui.directives').directive('uiDate', ['ui.config', function (uiConfig) {
+angular.module('ui.directives')
+
+.directive('uiDate', ['ui.config', function (uiConfig) {
   'use strict';
   var options;
   options = {};
@@ -25,7 +27,8 @@ angular.module('ui.directives').directive('uiDate', ['ui.config', function (uiCo
         if (controller) {
           var updateModel = function () {
             scope.$apply(function () {
-              controller.$setViewValue(element.datepicker("getDate"));
+              var date = element.datepicker("getDate");
+              controller.$setViewValue(date);
             });
           };
           if (opts.onSelect) {
@@ -45,11 +48,10 @@ angular.module('ui.directives').directive('uiDate', ['ui.config', function (uiCo
           // Update the date picker when the model changes
           controller.$render = function () {
             var date = controller.$viewValue;
-            element.datepicker("setDate", date);
-            // Update the model if we received a string
-            if (angular.isString(date)) {
-              controller.$setViewValue(element.datepicker("getDate"));
+            if ( date && !angular.isDate(date) ) {
+              throw new Error('ng-Model value must be a Date object - currently it is a ' + typeof date + ' - use ui-date-format to convert it from a string');
             }
+            element.datepicker("setDate", date);
           };
         }
         // If we don't destroy the old one it doesn't update properly when the config changes
@@ -64,4 +66,31 @@ angular.module('ui.directives').directive('uiDate', ['ui.config', function (uiCo
     }
   };
 }
-]);
+])
+
+.directive('uiDateFormat', [function() {
+  var directive = {
+    require:'ngModel',
+    link: function(scope, element, attrs, modelCtrl) {
+      if ( attrs.uiDateFormat === '' ) {
+        // Default to ISO formatting
+        modelCtrl.$formatters.push(function(value) {
+          return new Date(value);
+        });
+        modelCtrl.$parsers.push(function(value){
+          return value.toISOString();
+        });
+      } else {
+        var format = attrs.uiDateFormat;
+        // Use the datepicker with the attribute value as the format string to convert to and from a string
+        modelCtrl.$formatters.push(function(value) {
+          return $.datepicker.parseDate(format, value);
+        });
+        modelCtrl.$parsers.push(function(value){
+          return $.datepicker.formatDate(format, value);
+        });
+      }
+    }
+  };
+  return directive;
+}]);

--- a/modules/directives/date/date.js
+++ b/modules/directives/date/date.js
@@ -28,6 +28,7 @@ angular.module('ui.directives')
           var updateModel = function () {
             scope.$apply(function () {
               var date = element.datepicker("getDate");
+              element.datepicker("setDate", element.val());
               controller.$setViewValue(date);
             });
           };

--- a/modules/directives/date/test/dateSpec.js
+++ b/modules/directives/date/test/dateSpec.js
@@ -47,6 +47,26 @@ describe('uiDate', function() {
     });
   });
 
+  it('should update the input field correctly on a manual update', function() {
+      inject(function($compile, $rootScope) {
+          var dateString = '2012-08-17';
+          var dateObj = $.datepicker.parseDate('yy-mm-dd', dateString);
+          var element = $compile('<input ui-date="{dateFormat: \'yy-mm-dd\'}" ng-model="x"/>')($rootScope);
+          $rootScope.$apply(function() {
+              $rootScope.x = dateObj;
+          });
+          // Now change the data in the input box
+          dateString = '2012-8-01';
+          dateObj = $.datepicker.parseDate('yy-mm-dd', dateString);
+          element.val(dateString);
+          element.trigger("change");
+          expect(element.datepicker('getDate')).toEqual(dateObj);
+          expect(element.val()).toEqual('2012-08-01');
+          $rootScope.$digest();
+          expect($rootScope.x).toEqual(dateObj);
+      });
+  });
+
   describe('use with ng-required directive', function() {
     it('should be invalid initially', function() {
       inject(function($compile, $rootScope) {

--- a/modules/directives/date/test/dateSpec.js
+++ b/modules/directives/date/test/dateSpec.js
@@ -37,17 +37,6 @@ describe('uiDate', function() {
       });
     });
   });
-  it('should parse the date correctly from a string', function() {
-    inject(function($compile, $rootScope) {
-      var aDateString, element;
-      aDateString = '2012-08-17';
-      element = $compile('<input ui-date="{dateFormat: \'yy-mm-dd\'}" ng-model="x"/>')($rootScope);
-      $rootScope.$apply(function() {
-        $rootScope.x = aDateString;
-      });
-      expect($.datepicker.formatDate('yy-mm-dd', element.datepicker('getDate'))).toEqual(aDateString);
-    });
-  });
   it('should not freak out when the model is null', function() {
     inject(function($compile, $rootScope) {
       var element = $compile('<input ui-date="{dateFormat: \'yy-mm-dd\'}" ng-model="x"/>')($rootScope);
@@ -164,6 +153,34 @@ describe('uiDate', function() {
           $rootScope.config.minDate = 10;
         });
         expect(element.datepicker("option", "minDate")).toBe(10);
+      });
+    });
+  });
+
+  describe('use with the ui-date-format directive', function() {
+    it('should parse the date correctly from an ISO string', function() {
+      inject(function($compile, $rootScope) {
+        var aDateString, element;
+        aDateString = (new Date(2012,8,17)).toISOString();
+        element = $compile('<input ui-date ui-date-format ng-model="x"/>')($rootScope);
+        $rootScope.$apply(function() {
+          $rootScope.x = aDateString;
+        });
+        expect($rootScope.x).toEqual(aDateString);
+        expect($.datepicker.formatDate('yy-mm-dd', element.datepicker('getDate'))).toEqual('2012-09-17');
+      });
+    });
+    it('should parse the date correctly from a custom string', function() {
+      inject(function($compile, $rootScope) {
+        var format = 'DD, d MM, yy';
+        var aDateString = "Thursday, 11 October, 2012";
+        var element = $compile('<input ui-date ui-date-format="'+ format + '" ng-model="x"/>')($rootScope);
+        $rootScope.$apply(function() {
+          $rootScope.x = aDateString;
+        });
+        expect($rootScope.x).toEqual(aDateString);
+        expect($.datepicker.formatDate(format, element.datepicker('getDate'))).toEqual(aDateString);
+        expect(element.datepicker('getDate')).toEqual(new Date(2012, 9, 11));
       });
     });
   });


### PR DESCRIPTION
This is a proposed solution to the on-going problems people have with passing strings to the ui-date directive via ng-model.  The problem is how to tell the date directive how to parse strings that may have dates in a variety of formats.  See https://github.com/angular-ui/angular-ui/pull/217

The solution goes as follows:

1) The ui-date directive only accepts javascript Date objects in ng-model.  This is clean and clear.  Application developers can manipulate their scope to provide objects rather than strings.  The date directive does not conversion of strings and in fact throws an exception if one tries to pass a non-Date to it.
2) A second directive ui-date-format can be used in conjunction to ui-date to pre-parse/post-format strings from a specified date format into Date objects for the ui-date directive to consume.  This ensures that a Date object is provided to the ui-date directive and also that the scope object is always a string in the format specified.  The date-format directive would default, if not given a format string to ISO date formats.  The format strings allowed would follow what is allowed by the jquery ui datepicker.

Example usage:

``` javascript
$scope.myDate = '12 May 2012';
```

``` html
<input ui-date ng-model="myDate" ui-date-format="dd MM yy"/>
```
