### PR TITLE
Keep ui-date input field in sync with date picker for manual input

### DIFF
--- a/modules/directives/date/date.js
+++ b/modules/directives/date/date.js
@@ -40,7 +40,13 @@ angular.module('ui.directives').directive('uiDate', ['ui.config', function (uiCo
             opts.onSelect = updateModel;
           }
           // In case the user changes the text directly in the input box
-          element.bind('change', updateModel);
+          element.bind('change', function() {
+              var date = element.datepicker("getDate");
+              element.datepicker("setDate", element.val());
+              if (!angular.equals(date, element.datepicker("getDate"))) {
+                  updateModel();
+              }
+          });
 
           // Update the date picker when the model changes
           controller.$render = function () {

--- a/modules/directives/date/test/dateSpec.js
+++ b/modules/directives/date/test/dateSpec.js
@@ -58,6 +58,21 @@ describe('uiDate', function() {
     });
   });
 
+  it('should update the input field correctly on a manual update', function() {
+      inject(function($compile, $rootScope) {
+          var aDateString, element;
+          aDateString = '2012-08-17';
+          element = $compile('<input ui-date="{dateFormat: \'yy-mm-dd\'}" ng-model="x"/>')($rootScope);
+          $rootScope.$apply(function() {
+              $rootScope.x = aDateString;
+          });
+          element.val('2012-8-01');
+          element.trigger("change");
+          expect($.datepicker.formatDate('yy-mm-dd', element.datepicker('getDate'))).toEqual('2012-08-01');
+          expect(element.val()).toEqual('2012-08-01');
+      });
+  });
+
   describe('use with ng-required directive', function() {
     it('should be invalid initially', function() {
       inject(function($compile, $rootScope) {


### PR DESCRIPTION
When entering a date manually in an input field the date picker isn't always updated and will put the previously selected date in the model. Likewise, the input field itself isn't updated reflecting the date which is in the model. This pull request fixes that by setting the date on the date picker in the change event and if the date really changed, calling updateModel to get the Angular model updated.
