### PR TITLE
select2 "disabled" attribute improved

### DIFF
--- a/modules/directives/select2/select2.js
+++ b/modules/directives/select2/select2.js
@@ -87,7 +87,7 @@ angular.module('ui.directives').directive('uiSelect2', ['ui.config', '$http', fu
         }
 
         attrs.$observe('disabled', function (value) {
-          elm.select2(value && 'disable' || 'enable');
+          setDisabled(elm, value);
         });
 
         // Set initial value since Angular doesn't
@@ -96,8 +96,13 @@ angular.module('ui.directives').directive('uiSelect2', ['ui.config', '$http', fu
         // Initialize the plugin late so that the injected DOM does not disrupt the template compiler
         setTimeout(function () {
           elm.select2(opts);
+		  setDisabled(elm, attrs.disabled);
         });
       };
     }
   };
+  function setDisabled(elm, value) {
+    value = (value === 'false') ? false : value;
+    elm.select2(value && 'disable' || 'enable');
+  }
 }]);

--- a/modules/directives/select2/select2.js
+++ b/modules/directives/select2/select2.js
@@ -96,7 +96,7 @@ angular.module('ui.directives').directive('uiSelect2', ['ui.config', '$http', fu
         // Initialize the plugin late so that the injected DOM does not disrupt the template compiler
         setTimeout(function () {
           elm.select2(opts);
-		  setDisabled(elm, attrs.disabled);
+          setDisabled(elm, attrs.disabled);
         });
       };
     }


### PR DESCRIPTION
The disabled attribute is only taken into account if it changed after initialization, so
<input ui-select2 disabled="true"> 
does NOT work.

The disabled attribute is interpreted as string, so every value apart from null and empty string is true, so
<input ui-select2 disabled="{{booleanFlag}}">
is always disabled.

This change fixes both issues.
