### PR TITLE
Adding tests for false and undefined

### DIFF
--- a/modules/directives/date/date.js
+++ b/modules/directives/date/date.js
@@ -49,7 +49,7 @@ angular.module('ui.directives')
           // Update the date picker when the model changes
           controller.$render = function () {
             var date = controller.$viewValue;
-            if ( date && !angular.isDate(date) ) {
+            if ( angular.isDefined(date) && date !== null && !angular.isDate(date) ) {
               throw new Error('ng-Model value must be a Date object - currently it is a ' + typeof date + ' - use ui-date-format to convert it from a string');
             }
             element.datepicker("setDate", date);
@@ -76,31 +76,31 @@ angular.module('ui.directives')
       if ( attrs.uiDateFormat === '' ) {
         // Default to ISO formatting
         modelCtrl.$formatters.push(function(value) {
-          if (value)
+          if (angular.isString(value) ) {
             return new Date(value);
-          else
-            return value;
+          }
+          return null;
         });
         modelCtrl.$parsers.push(function(value){
-          if (value)
+          if (angular.isString(value) ) {
             return value.toISOString();
-          else
-            return value;
+          }
+          return null;
         });
       } else {
         var format = attrs.uiDateFormat;
         // Use the datepicker with the attribute value as the format string to convert to and from a string
         modelCtrl.$formatters.push(function(value) {
-          if (value)
+          if (angular.isString(value) ) {
             return $.datepicker.parseDate(format, value);
-          else
-            return value;
+          }
+          return null;
         });
         modelCtrl.$parsers.push(function(value){
-          if (value)
+          if (angular.isString(value) ) {
             return $.datepicker.formatDate(format, value);
-          else
-            return value;
+          }
+          return null;
         });
       }
     }

--- a/modules/directives/date/test/dateSpec.js
+++ b/modules/directives/date/test/dateSpec.js
@@ -46,6 +46,24 @@ describe('uiDate', function() {
       expect(element.datepicker('getDate')).toBe(null);
     });
   });
+  it('should not freak out when the model is undefined', function() {
+    inject(function($compile, $rootScope) {
+      var element = $compile('<input ui-date="{dateFormat: \'yy-mm-dd\'}" ng-model="x"/>')($rootScope);
+      $rootScope.$apply(function() {
+        $rootScope.x = undefined;
+      });
+      expect(element.datepicker('getDate')).toBe(undefined);
+    });
+  });
+  it('should not freak out when the model is false', function() {
+    inject(function($compile, $rootScope) {
+      var element = $compile('<input ui-date="{dateFormat: \'yy-mm-dd\'}" ng-model="x"/>')($rootScope);
+      $rootScope.$apply(function() {
+        $rootScope.x = false;
+      });
+      expect(element.datepicker('getDate')).toBe(false);
+    });
+  });
 
   it('should update the input field correctly on a manual update', function() {
       inject(function($compile, $rootScope) {
@@ -201,6 +219,41 @@ describe('uiDate', function() {
         expect($rootScope.x).toEqual(aDateString);
         expect($.datepicker.formatDate(format, element.datepicker('getDate'))).toEqual(aDateString);
         expect(element.datepicker('getDate')).toEqual(new Date(2012, 9, 11));
+      });
+    });
+    it('should not freak out when the model is false', function() {
+      inject(function($compile, $rootScope) {
+         var aDateString, element;
+          element = $compile('<input ui-date ui-date-format ng-model="x"/>')($rootScope);
+          $rootScope.$apply(function() {
+            $rootScope.x = false;
+          });
+          expect($rootScope.x).toBe(false);
+          expect(element.val()).toEqual('');
+      });
+    });
+    
+    it('should not freak out when the model is undefined', function() {
+      inject(function($compile, $rootScope) {
+         var aDateString, element;
+          element = $compile('<input ui-date ui-date-format ng-model="x"/>')($rootScope);
+          $rootScope.$apply(function() {
+            $rootScope.x = undefined;
+          });
+          expect($rootScope.x).toBe(undefined);
+          expect(element.val()).toEqual('');
+      });
+    });
+    
+    it('should not freak out when the model is null', function() {
+      inject(function($compile, $rootScope) {
+         var aDateString, element;
+          element = $compile('<input ui-date ui-date-format ng-model="x"/>')($rootScope);
+          $rootScope.$apply(function() {
+            $rootScope.x = null;
+          });
+          expect($rootScope.x).toBe(null);
+          expect(element.val()).toEqual('');
       });
     });
   });

--- a/modules/directives/date/test/dateSpec.js
+++ b/modules/directives/date/test/dateSpec.js
@@ -37,31 +37,31 @@ describe('uiDate', function() {
       });
     });
   });
-  it('should not freak out when the model is null', function() {
-    inject(function($compile, $rootScope) {
-      var element = $compile('<input ui-date="{dateFormat: \'yy-mm-dd\'}" ng-model="x"/>')($rootScope);
-      $rootScope.$apply(function() {
-        $rootScope.x = null;
+  describe('when model is not a Date', function() {
+    var element;
+    var scope;
+    beforeEach(inject(function($compile, $rootScope) {
+      element = $compile('<input ui-date="{dateFormat: \'yy-mm-dd\'}" ng-model="x"/>')($rootScope);
+      scope = $rootScope;
+    }));
+    it('should not freak out when the model is null', function() {
+      scope.$apply(function() {
+        scope.x = null;
       });
       expect(element.datepicker('getDate')).toBe(null);
     });
-  });
-  it('should not freak out when the model is undefined', function() {
-    inject(function($compile, $rootScope) {
-      var element = $compile('<input ui-date="{dateFormat: \'yy-mm-dd\'}" ng-model="x"/>')($rootScope);
-      $rootScope.$apply(function() {
-        $rootScope.x = undefined;
+    it('should not freak out when the model is undefined', function() {
+      scope.$apply(function() {
+        scope.x = undefined;
       });
-      expect(element.datepicker('getDate')).toBe(undefined);
+      expect(element.datepicker('getDate')).toBe(null);
     });
-  });
-  it('should not freak out when the model is false', function() {
-    inject(function($compile, $rootScope) {
-      var element = $compile('<input ui-date="{dateFormat: \'yy-mm-dd\'}" ng-model="x"/>')($rootScope);
-      $rootScope.$apply(function() {
-        $rootScope.x = false;
-      });
-      expect(element.datepicker('getDate')).toBe(false);
+    it('should throw an error if you try to pass in a boolean when the model is false', function() {
+      expect(function() {
+        scope.$apply(function() {
+          scope.x = false;
+        });
+      }).toThrow();
     });
   });
 
@@ -229,7 +229,7 @@ describe('uiDate', function() {
             $rootScope.x = false;
           });
           expect($rootScope.x).toBe(false);
-          expect(element.val()).toEqual('');
+          expect(element.datepicker('getDate')).toEqual(null);
       });
     });
     
@@ -241,7 +241,7 @@ describe('uiDate', function() {
             $rootScope.x = undefined;
           });
           expect($rootScope.x).toBe(undefined);
-          expect(element.val()).toEqual('');
+          expect(element.datepicker('getDate')).toEqual(null);
       });
     });
     
@@ -253,7 +253,7 @@ describe('uiDate', function() {
             $rootScope.x = null;
           });
           expect($rootScope.x).toBe(null);
-          expect(element.val()).toEqual('');
+          expect(element.datepicker('getDate')).toEqual(null);
       });
     });
   });


### PR DESCRIPTION
They are currently failing however as I'm not exactly sure I'm testing things correctly.

I would like to have the uiDate degrade gracefully when falsy values are passed. I had an error when ui-date-format was being used if the model was set to undefined. Instead of getting a viable error message, I got `Invalid Arguments` due to the formatter/parser being executed incorrectly.
