### PR TITLE
Added a check to prevent recursive $digest in TinyMCE

### DIFF
--- a/modules/directives/tinymce/test/tinymceSpec.js
+++ b/modules/directives/tinymce/test/tinymceSpec.js
@@ -47,5 +47,46 @@ describe('uiTinymce', function () {
       });
     });
   });
-
+  describe('setting a value to the model', function () {
+    it('should update the editor', function() {
+      inject(function($compile, $rootScope) {
+        var element, text = '<p>Hello</p>';
+        element = $compile("<textarea ui-tinymce ng-model='x'></textarea>")($rootScope);
+        $rootScope.$apply(function() {
+          $rootScope.x = text;
+        });
+        expect(element.find('textarea').tinymce().getContent()).toEqual(text);
+      });
+    });
+    it('should handle undefined gracefully', function() {
+      inject(function($compile, $rootScope) {
+        var element;
+        element = $compile("<textarea ui-tinymce ng-model='x'></textarea>")($rootScope);
+        $rootScope.$apply(function() {
+          $rootScope.x = undefined;
+        });
+        expect(element.find('textarea').tinymce().getContent()).toEqual('');
+      });
+    });
+    it('should handle null gracefully', function() {
+      inject(function($compile, $rootScope) {
+        var element;
+        element = $compile("<textarea ui-tinymce ng-model='x'></textarea>")($rootScope);
+        $rootScope.$apply(function() {
+          $rootScope.x = null;
+        });
+        expect(element.find('textarea').tinymce().getContent()).toEqual('');
+      });
+    });
+  });
+  describe('using the editor', function () {
+    it('should update the model', function() {
+      inject(function($compile, $rootScope) {
+        var element, text = '<p>Hello</p>';
+        element = $compile("<textarea ui-tinymce ng-model='x'></textarea>")($rootScope);
+        element.find('textarea').tinymce().setContent(text);
+        expect($rootScope.x).toEqual(text);
+      });
+    });
+  });
 });

--- a/modules/directives/tinymce/tinymce.js
+++ b/modules/directives/tinymce/tinymce.js
@@ -13,7 +13,8 @@ angular.module('ui.directives').directive('uiTinymce', ['ui.config', function (u
             if (inst.isDirty()) {
               inst.save();
               ngModel.$setViewValue(elm.val());
-              scope.$apply();
+              if (!scope.$$phase)
+                scope.$apply();
             }
           },
           // Update model on keypress
@@ -21,7 +22,8 @@ angular.module('ui.directives').directive('uiTinymce', ['ui.config', function (u
             if (this.isDirty()) {
               this.save();
               ngModel.$setViewValue(elm.val());
-              scope.$apply();
+              if (!scope.$$phase)
+                scope.$apply();
             }
             return true; // Continue handling
           },
@@ -31,7 +33,8 @@ angular.module('ui.directives').directive('uiTinymce', ['ui.config', function (u
               if (ed.isDirty()) {
                 ed.save();
                 ngModel.$setViewValue(elm.val());
-                scope.$apply();
+                if (!scope.$$phase)
+                  scope.$apply();
               }
             });
           }

--- a/test/test-config.js
+++ b/test/test-config.js
@@ -16,6 +16,7 @@ files = [
   'test/lib/angular-1.0.1/angular.js',
   'test/lib/angular-1.0.1/angular-mocks.js',
   'test/lib/codemirror/codemirror.js',
+  'test/lib/tinymce/tiny_mce.js',
   'test/lib/tinymce/jquery.tinymce.js',
   'test/lib/googlemaps/googlemaps.js',
   'test/lib/bootstrap/bootstrap-modal.js',


### PR DESCRIPTION
This may hopefully help us solve some more problems. I am trying to add some tests but I cannot seem to properly find the <textarea> element if someone could help me with them.

I'm wondering if I should populate `$render`, it doesn't seem to be necessary though since I imagine TinyMCE triggers a change or update or something. In addition it appears that TinyMCE with jQuery hooks into the `.val()` and `.html()` methods.
