### PR TITLE
modal: add support for autofocus

### DIFF
--- a/modules/directives/modal/modal.js
+++ b/modules/directives/modal/modal.js
@@ -6,6 +6,9 @@ angular.module('ui.directives')
     link: function(scope, elm, attrs, model) {
       //helper so you don't have to type class="modal hide"
       elm.addClass('modal hide');
+	  elm.on( 'shown', function() {
+		elm.find( "[autofocus]" ).focus();
+	  } );
       scope.$watch(attrs.ngModel, function(value) {
         elm.modal(value && 'show' || 'hide');
       });


### PR DESCRIPTION
automatically set focus on element with [autofocus] attribute when modal is shown.
