### PR TITLE
Replaced trim() method in select2 directive

### DIFF
--- a/modules/directives/select2/select2.js
+++ b/modules/directives/select2/select2.js
@@ -22,10 +22,10 @@ angular.module('ui.directives').directive('uiSelect2', ['ui.config', '$http', fu
       // Enable watching of the options dataset if in use
       if (tElm.is('select')) {
         repeatOption = tElm.find('option[ng-repeat], option[data-ng-repeat]');
-		
+
         if (repeatOption.length) {
 		  repeatAttr = repeatOption.attr('ng-repeat') || repeatOption.attr('data-ng-repeat');
-          watch = repeatAttr.split('|')[0].trim().split(' ').pop();
+          watch = repeatAttr.split('|')[0].replace(/^\s+|\s+$/g,"").split(' ').pop();
         }
       }
 


### PR DESCRIPTION
Trim is not available in IE8 and below. This causes the select2 to fail
when <option ng-repeat> is used.

This commit replaces the trim method with a standard unobtrusive regex.
