### PR TITLE
Jq: Do not copy element options to the defaults

### DIFF
--- a/modules/directives/jq/jq.js
+++ b/modules/directives/jq/jq.js
@@ -27,7 +27,7 @@ angular.module('ui.directives').directive('uiJq', ['ui.config', function (uiConf
         if (attrs.uiOptions) {
           linkOptions = scope.$eval('[' + attrs.uiOptions + ']');
           if (angular.isObject(options) && angular.isObject(linkOptions[0])) {
-            linkOptions[0] = angular.extend(options, linkOptions[0]);
+            linkOptions[0] = angular.extend({}, options, linkOptions[0]);
           }
         } else if (options) {
           linkOptions = [options];

--- a/modules/directives/jq/test/jqSpec.js
+++ b/modules/directives/jq/test/jqSpec.js
@@ -2,6 +2,13 @@ describe('uiJq', function () {
   var scope;
   scope = null;
   beforeEach(module('ui.directives'));
+  beforeEach(function () {
+    module(function ($provide) {
+      $provide.value('ui.config', {
+        jq: {joe: {}}
+      });
+    });
+  });
   beforeEach(inject(function ($rootScope) {
     scope = $rootScope.$new();
   }));
@@ -22,6 +29,18 @@ describe('uiJq', function () {
         spyOn($.fn, 'success');
         $compile("<div ui-jq='success'></div>")(scope);
         expect($.fn.success).toHaveBeenCalled();
+      });
+    });
+  });
+  describe('calling a jQuery element function with options', function() {
+    it('should not copy options.pizza to global', function() {
+      inject(function ($compile) {
+        $.fn.joe = function () {
+        };
+        spyOn($.fn, 'joe');
+        $compile('<div ui-jq="joe" ui-options="{pizza:true}"></div><div ui-jq="joe" ui-options="{}"></div>')(scope);
+        expect($.fn.joe.calls[0].args).toEqual([{pizza: true}]);
+        expect($.fn.joe.calls[1].args).toEqual([{}]);
       });
     });
   });


### PR DESCRIPTION
When using multiple Jq directives, elements options (from `ui-options` attribute) are copied to the global default options and then they are applied to all latter directive instances.
