### PR TITLE
This fixes a missing scope.$apply() in the ui-date onSelect event

### DIFF
--- a/modules/directives/date/date.js
+++ b/modules/directives/date/date.js
@@ -38,7 +38,7 @@ angular.module('ui.directives')
             opts.onSelect = function (value, picker) {
               updateModel();
               scope.$apply(function() {
-                  userHandler(value, picker);
+                userHandler(value, picker);
               });
             };
           } else {

--- a/modules/directives/date/date.js
+++ b/modules/directives/date/date.js
@@ -37,11 +37,9 @@ angular.module('ui.directives')
             var userHandler = opts.onSelect;
             opts.onSelect = function (value, picker) {
               updateModel();
-              var ret = null;
               scope.$apply(function() {
-                  ret = userHandler(value, picker);
+                  userHandler(value, picker);
               });
-              return ret
             };
           } else {
             // No onSelect already specified so just update the model

--- a/modules/directives/date/date.js
+++ b/modules/directives/date/date.js
@@ -37,7 +37,11 @@ angular.module('ui.directives')
             var userHandler = opts.onSelect;
             opts.onSelect = function (value, picker) {
               updateModel();
-              return userHandler(value, picker);
+              var ret = null;
+              scope.$apply(function() {
+                  ret = userHandler(value, picker);
+              });
+              return ret
             };
           } else {
             // No onSelect already specified so just update the model

--- a/modules/directives/date/test/dateSpec.js
+++ b/modules/directives/date/test/dateSpec.js
@@ -85,6 +85,27 @@ describe('uiDate', function() {
       });
   });
 
+  describe("use with user events", function() {
+    it('should call the user onSelect event within a scope.$apply context', function() {
+      inject(function($compile, $rootScope) {
+        var watched = false;
+        $rootScope.myDateSelected = function() {
+          $rootScope.watchMe = true;
+        }
+        $rootScope.$watch("watchMe", function(watchMe) {
+          if (watchMe) {
+            watched = true;
+          }
+        });
+        var aDate = new Date(2012,9,11);
+        var element = $compile('<input ui-date="{onSelect: myDateSelected}" ng-model="x"/>')($rootScope);
+        $rootScope.$apply();
+        selectDate(element, aDate);
+        expect(watched).toBeTruthy();
+      });
+    });
+  });
+
   describe('use with ng-required directive', function() {
     it('should be invalid initially', function() {
       inject(function($compile, $rootScope) {


### PR DESCRIPTION
Prior to this commit, callers' onSelect handler would need to use its
own $scope.$apply() for changes to $scope to take effect as a result of
an onSelect event.
