### PR TITLE
TDD fix for missing scope.$apply() in ui-date onSelect

### DIFF
--- a/modules/directives/date/date.js
+++ b/modules/directives/date/date.js
@@ -37,7 +37,9 @@ angular.module('ui.directives')
             var userHandler = opts.onSelect;
             opts.onSelect = function (value, picker) {
               updateModel();
-              return userHandler(value, picker);
+              scope.$apply(function() {
+                userHandler(value, picker);
+              });
             };
           } else {
             // No onSelect already specified so just update the model

--- a/modules/directives/date/test/dateSpec.js
+++ b/modules/directives/date/test/dateSpec.js
@@ -85,6 +85,27 @@ describe('uiDate', function() {
       });
   });
 
+  describe("use with user events", function() {
+    it('should call the user onSelect event within a scope.$apply context', function() {
+      inject(function($compile, $rootScope) {
+        var watched = false;
+        $rootScope.myDateSelected = function() {
+          $rootScope.watchMe = true;
+        }
+        $rootScope.$watch("watchMe", function(watchMe) {
+          if (watchMe) {
+            watched = true;
+          }
+        });
+        var aDate = new Date(2012,9,11);
+        var element = $compile('<input ui-date="{onSelect: myDateSelected}" ng-model="x"/>')($rootScope);
+        $rootScope.$apply();
+        selectDate(element, aDate);
+        expect(watched).toBeTruthy();
+      });
+    });
+  });
+
   describe('use with ng-required directive', function() {
     it('should be invalid initially', function() {
       inject(function($compile, $rootScope) {


### PR DESCRIPTION
Previously, the onSelect caller would have to do its own $scope.$apply(). Now we do it for them to be consistent with the rest of Angular.
