### PR TITLE
Select2: Use the val method for array $modelValue

### DIFF
--- a/modules/directives/select2/select2.js
+++ b/modules/directives/select2/select2.js
@@ -49,6 +49,8 @@ angular.module('ui.directives').directive('uiSelect2', ['ui.config', '$http', fu
             } else {
               if (isMultiple && !controller.$modelValue) {
                 elm.select2('data', []);
+              } else if (angular.isArray(controller.$modelValue)) {
+                elm.select2('val', controller.$modelValue);
               } else if (angular.isObject(controller.$modelValue)) {
                 elm.select2('data', controller.$modelValue);
               } else {


### PR DESCRIPTION
The check, `angular.isObject(controller.$modelValue)` will return
`true` if `controller.$modelValue` is an array.

Select2 insists on using the `val` method for arrays.
