### PR TITLE
Enhancements to the passthrough directive

### DIFF
--- a/modules/directives/jq/jq.js
+++ b/modules/directives/jq/jq.js
@@ -4,14 +4,15 @@
  * It is possible to specify a default set of parameters for each jQuery plugin.
  * Under the jq key, namespace each plugin by that which will be passed to ui-jq.
  * Unfortunately, at this time you can only pre-define the first parameter.
- * @example { jq : { datepicker : { showOn:'click' } } }
+ * @example { jq : { datepicker : { showOn:'click', uiDefer: true } } }
  *
  * @param ui-jq {string} The $elm.[pluginName]() to call.
  * @param [ui-options] {mixed} Expression to be evaluated and passed as options to the function
  *     Multiple parameters can be separated by commas
- *    Set {ngChange:false} to disable passthrough support for change events ( since angular watches 'input' events, not 'change' events )
+ * @param [ui-defer] or use ui.config.jq.{yourPlugin}.uiDefer = true to defer execution (wait until after AngularJS finishes rendering)
+ * @param [ui-refresh] {expression} Watch expression and refire plugin on changes
  *
- * @example <input ui-jq="datepicker" ui-options="{showOn:'click'},secondParameter,thirdParameter">
+ * @example <input ui-jq="datepicker" ui-options="{showOn:'click'},secondParameter,thirdParameter" ui-refresh="iChange" ui-defer>
  */
 angular.module('ui.directives').directive('uiJq', ['ui.config', function (uiConfig) {
   return {
@@ -22,8 +23,9 @@ angular.module('ui.directives').directive('uiJq', ['ui.config', function (uiConf
       }
       var options = uiConfig.jq && uiConfig.jq[tAttrs.uiJq];
       return function (scope, elm, attrs) {
-        var linkOptions = [], ngChange = 'change';
+        var linkOptions = [], uiDefer = false;
 
+        // If ui-options are passed, merge (or override) them onto global defaults and pass to the jQuery method
         if (attrs.uiOptions) {
           linkOptions = scope.$eval('[' + attrs.uiOptions + ']');
           if (angular.isObject(options) && angular.isObject(linkOptions[0])) {
@@ -32,17 +34,37 @@ angular.module('ui.directives').directive('uiJq', ['ui.config', function (uiConf
         } else if (options) {
           linkOptions = [options];
         }
+        // If change compatibility is enabled, the form input's "change" event will trigger an "input" event
         if (attrs.ngModel && elm.is('select,input,textarea')) {
-          if (linkOptions && angular.isObject(linkOptions[0]) && linkOptions[0].ngChange !== undefined) {
-            ngChange = linkOptions[0].ngChange;
-          }
-          if (ngChange) {
-            elm.on(ngChange, function () {
-              elm.trigger('input');
+          elm.on('change', function () {
+            elm.trigger('input');
+          });
+        }
+        // If uiConfig.jq.{yourPlugin}.uiDefer is true OR you have a ui-defer attribute, initialize the plugin in a timeout
+        if (uiOptions.jq[attrs.uiJq].uiDefer || attrs.uiDefer !== undefined) {
+          uiDefer = true
+          delete true;
+        }
+
+        // If ui-refresh is used, re-fire the the method upon every change
+        if (attrs.uiRefresh) {
+          scope.$watch(attrs.uiRefresh, function(){
+            callPlugin();
+          });
+        } else {
+          callPlugin();
+        }
+
+        // Call jQuery method and pass relevant options
+        function callPlugin() {
+          if (uiDefer) {
+            scope.$evalAsync(function(){
+              elm[attrs.uiJq].apply(elm, linkOptions);
             });
+          } else {
+            elm[attrs.uiJq].apply(elm, linkOptions);
           }
         }
-        elm[attrs.uiJq].apply(elm, linkOptions);
       };
     }
   };

--- a/modules/directives/jq/jq.js
+++ b/modules/directives/jq/jq.js
@@ -9,10 +9,9 @@
  * @param ui-jq {string} The $elm.[pluginName]() to call.
  * @param [ui-options] {mixed} Expression to be evaluated and passed as options to the function
  *     Multiple parameters can be separated by commas
- * @param [ui-defer] or use ui.config.jq.{yourPlugin}.uiDefer = true to defer execution (wait until after AngularJS finishes rendering)
  * @param [ui-refresh] {expression} Watch expression and refire plugin on changes
  *
- * @example <input ui-jq="datepicker" ui-options="{showOn:'click'},secondParameter,thirdParameter" ui-refresh="iChange" ui-defer>
+ * @example <input ui-jq="datepicker" ui-options="{showOn:'click'},secondParameter,thirdParameter" ui-refresh="iChange">
  */
 angular.module('ui.directives').directive('uiJq', ['ui.config', function (uiConfig) {
   return {
@@ -39,11 +38,6 @@ angular.module('ui.directives').directive('uiJq', ['ui.config', function (uiConf
           elm.on('change', function () {
             elm.trigger('input');
           });
-        }
-        // If options.uiDefer is true OR you have a ui-defer attribute, initialize the plugin in a timeout
-        if (options.uiDefer || attrs.uiDefer !== undefined) {
-          uiDefer = true
-          delete linkOptions[0].uiDefer;
         }
 
         // Call jQuery method and pass relevant options

--- a/modules/directives/jq/jq.js
+++ b/modules/directives/jq/jq.js
@@ -21,7 +21,7 @@ angular.module('ui.directives').directive('uiJq', ['ui.config', function (uiConf
       if (!angular.isFunction(tElm[tAttrs.uiJq])) {
         throw new Error('ui-jq: The "' + tAttrs.uiJq + '" function does not exist');
       }
-      var options = uiConfig.jq && uiConfig.jq[tAttrs.uiJq];
+      var options = uiConfig.jq && uiConfig.jq[tAttrs.uiJq] || {};
       return function (scope, elm, attrs) {
         var linkOptions = [], uiDefer = false;
 
@@ -40,19 +40,10 @@ angular.module('ui.directives').directive('uiJq', ['ui.config', function (uiConf
             elm.trigger('input');
           });
         }
-        // If uiConfig.jq.{yourPlugin}.uiDefer is true OR you have a ui-defer attribute, initialize the plugin in a timeout
-        if (uiOptions.jq[attrs.uiJq].uiDefer || attrs.uiDefer !== undefined) {
+        // If options.uiDefer is true OR you have a ui-defer attribute, initialize the plugin in a timeout
+        if (options.uiDefer || attrs.uiDefer !== undefined) {
           uiDefer = true
-          delete true;
-        }
-
-        // If ui-refresh is used, re-fire the the method upon every change
-        if (attrs.uiRefresh) {
-          scope.$watch(attrs.uiRefresh, function(){
-            callPlugin();
-          });
-        } else {
-          callPlugin();
+          delete linkOptions[0].uiDefer;
         }
 
         // Call jQuery method and pass relevant options
@@ -65,6 +56,15 @@ angular.module('ui.directives').directive('uiJq', ['ui.config', function (uiConf
             elm[attrs.uiJq].apply(elm, linkOptions);
           }
         }
+
+        // If ui-refresh is used, re-fire the the method upon every change
+        if (attrs.uiRefresh) {
+          scope.$watch(attrs.uiRefresh, function(){
+            callPlugin();
+          });
+        }
+        
+        callPlugin();
       };
     }
   };

--- a/modules/directives/jq/test/jqSpec.js
+++ b/modules/directives/jq/test/jqSpec.js
@@ -3,6 +3,7 @@ describe('uiJq', function () {
   scope = null;
   beforeEach(module('ui.directives'));
   beforeEach(function () {
+    jQuery.fn.foo = function () {};
     module(function ($provide) {
       $provide.value('ui.config', {
         jq: {foo: {}}
@@ -22,15 +23,13 @@ describe('uiJq', function () {
   });
   describe('calling a jQuery element function', function () {
     it('should just like, sort of work and junk', function () {
-      jQuery.fn.success = function () {};
-      spyOn(jQuery.fn, 'success');
-      compile("<div ui-jq='success'></div>")(scope);
-      expect(jQuery.fn.success).toHaveBeenCalled();
+      spyOn(jQuery.fn, 'foo');
+      compile("<div ui-jq='foo'></div>")(scope);
+      expect(jQuery.fn.foo).toHaveBeenCalled();
     });
   });
   describe('calling a jQuery element function with options', function() {
     it('should not copy options.pizza to global', function() {
-      jQuery.fn.foo = function () {};
       spyOn(jQuery.fn, 'foo');
       compile('<div ui-jq="foo" ui-options="{pizza:true}"></div><div ui-jq="foo" ui-options="{}"></div>')(scope);
       expect(jQuery.fn.foo.calls[0].args).toEqual([{pizza: true}]);
@@ -39,60 +38,52 @@ describe('uiJq', function () {
   });
   describe('using ui-refresh', function() {
     it('should execute exactly once if the expression is never set', function() {
-      jQuery.fn.foo = function () {
-        console.log('test');
-      };
       spyOn(jQuery.fn, 'foo');
       compile('<div ui-jq="foo" ui-refresh="bar"></div>')(scope);
       expect(jQuery.fn.foo.callCount).toBe(1);
     });
     it('should execute exactly once if the expression is set at initialization', function() {
-      jQuery.fn.foo = function () {};
       spyOn(jQuery.fn, 'foo');
-      scope.bar = true;
+      scope.$apply('bar = true');
       compile('<div ui-jq="foo" ui-refresh="bar"></div>')(scope);
       expect(jQuery.fn.foo.callCount).toBe(1);
     });
     it('should execute once for each time the expression changes', function() {
-      jQuery.fn.foo = function () {};
       spyOn(jQuery.fn, 'foo');
-      scope.bar = 1;
+      scope.$apply('bar = 1');
       compile('<div ui-jq="foo" ui-refresh="bar"></div>')(scope);
       expect(jQuery.fn.foo.callCount).toBe(1);
-      scope.$apply('bar++');
+      scope.$apply('bar = bar+1');
       expect(jQuery.fn.foo.callCount).toBe(2);
-      scope.$apply('bar++');
+      scope.$apply('bar = bar+1');
       expect(jQuery.fn.foo.callCount).toBe(3);
     });
   });
   describe('passing uiChange to options', function() {
     it('should watch a form control change event and trigger an input event if true', function() {
-      jQuery.fn.foo = function () {};
       var bar = false;
       var element = compile('<input ui-jq="foo">')(scope);
       element.bind('input', function(){
         bar = true;
-      })
+      });
       element.trigger('change');
       expect(bar).toBe(true);
     });
     it('should not watch a form control change event and trigger an input event if false', function() {
-      jQuery.fn.foo = function () {};
       var bar = false;
       var element = compile('<input ui-jq="foo" ui-options="{uiChange:false}">')(scope);
       element.bind('input', function(){
         bar = true;
-      })
+      });
       element.trigger('change');
       expect(bar).toBe(false);
     });
     it('should not watch non-form controls', function() {
-      jQuery.fn.foo = function () {};
       var bar = false;
       var element = compile('<div ui-jq="foo"></div>')(scope);
       element.bind('input', function(){
         bar = true;
-      })
+      });
       element.trigger('change');
       expect(bar).toBe(false);
     });

--- a/modules/directives/jq/test/jqSpec.js
+++ b/modules/directives/jq/test/jqSpec.js
@@ -1,47 +1,100 @@
 describe('uiJq', function () {
-  var scope;
+  var scope, compile;
   scope = null;
   beforeEach(module('ui.directives'));
   beforeEach(function () {
     module(function ($provide) {
       $provide.value('ui.config', {
-        jq: {joe: {}}
+        jq: {foo: {}}
       });
     });
   });
-  beforeEach(inject(function ($rootScope) {
+  beforeEach(inject(function ($rootScope, $compile) {
     scope = $rootScope.$new();
+    compile = $compile;
   }));
   describe('function or plugin isn\'t found', function () {
     it('should throw an error', function () {
-      inject(function ($compile) {
-        expect(function () {
-          $compile("<div ui-jq='failure'></div>")(scope);
-        }).toThrow();
-      });
+      expect(function () {
+        compile("<div ui-jq='failure'></div>")(scope);
+      }).toThrow();
     });
   });
   describe('calling a jQuery element function', function () {
     it('should just like, sort of work and junk', function () {
-      inject(function ($compile) {
-        $.fn.success = function () {
-        };
-        spyOn($.fn, 'success');
-        $compile("<div ui-jq='success'></div>")(scope);
-        expect($.fn.success).toHaveBeenCalled();
-      });
+      jQuery.fn.success = function () {};
+      spyOn(jQuery.fn, 'success');
+      compile("<div ui-jq='success'></div>")(scope);
+      expect(jQuery.fn.success).toHaveBeenCalled();
     });
   });
   describe('calling a jQuery element function with options', function() {
     it('should not copy options.pizza to global', function() {
-      inject(function ($compile) {
-        $.fn.joe = function () {
-        };
-        spyOn($.fn, 'joe');
-        $compile('<div ui-jq="joe" ui-options="{pizza:true}"></div><div ui-jq="joe" ui-options="{}"></div>')(scope);
-        expect($.fn.joe.calls[0].args).toEqual([{pizza: true}]);
-        expect($.fn.joe.calls[1].args).toEqual([{}]);
-      });
+      jQuery.fn.foo = function () {};
+      spyOn(jQuery.fn, 'foo');
+      compile('<div ui-jq="foo" ui-options="{pizza:true}"></div><div ui-jq="foo" ui-options="{}"></div>')(scope);
+      expect(jQuery.fn.foo.calls[0].args).toEqual([{pizza: true}]);
+      expect(jQuery.fn.foo.calls[1].args).toEqual([{}]);
+    });
+  });
+  describe('using ui-refresh', function() {
+    it('should execute exactly once if the expression is never set', function() {
+      jQuery.fn.foo = function () {
+        console.log('test');
+      };
+      spyOn(jQuery.fn, 'foo');
+      compile('<div ui-jq="foo" ui-refresh="bar"></div>')(scope);
+      expect(jQuery.fn.foo.callCount).toBe(1);
+    });
+    it('should execute exactly once if the expression is set at initialization', function() {
+      jQuery.fn.foo = function () {};
+      spyOn(jQuery.fn, 'foo');
+      scope.bar = true;
+      compile('<div ui-jq="foo" ui-refresh="bar"></div>')(scope);
+      expect(jQuery.fn.foo.callCount).toBe(1);
+    });
+    it('should execute once for each time the expression changes', function() {
+      jQuery.fn.foo = function () {};
+      spyOn(jQuery.fn, 'foo');
+      scope.bar = 1;
+      compile('<div ui-jq="foo" ui-refresh="bar"></div>')(scope);
+      expect(jQuery.fn.foo.callCount).toBe(1);
+      scope.$apply('bar++');
+      expect(jQuery.fn.foo.callCount).toBe(2);
+      scope.$apply('bar++');
+      expect(jQuery.fn.foo.callCount).toBe(3);
+    });
+  });
+  describe('passing uiChange to options', function() {
+    it('should watch a form control change event and trigger an input event if true', function() {
+      jQuery.fn.foo = function () {};
+      var bar = false;
+      var element = compile('<input ui-jq="foo">')(scope);
+      element.bind('input', function(){
+        bar = true;
+      })
+      element.trigger('change');
+      expect(bar).toBe(true);
+    });
+    it('should not watch a form control change event and trigger an input event if false', function() {
+      jQuery.fn.foo = function () {};
+      var bar = false;
+      var element = compile('<input ui-jq="foo" ui-options="{uiChange:false}">')(scope);
+      element.bind('input', function(){
+        bar = true;
+      })
+      element.trigger('change');
+      expect(bar).toBe(false);
+    });
+    it('should not watch non-form controls', function() {
+      jQuery.fn.foo = function () {};
+      var bar = false;
+      var element = compile('<div ui-jq="foo"></div>')(scope);
+      element.bind('input', function(){
+        bar = true;
+      })
+      element.trigger('change');
+      expect(bar).toBe(false);
     });
   });
 });

--- a/modules/directives/jq/test/jqSpec.js
+++ b/modules/directives/jq/test/jqSpec.js
@@ -59,28 +59,28 @@ describe('uiJq', function () {
       expect(jQuery.fn.foo.callCount).toBe(3);
     });
   });
-  describe('passing uiChange to options', function() {
-    it('should watch a form control change event and trigger an input event if true', function() {
+  describe('change events', function() {
+    it('should trigger an `input` event', function() {
       var bar = false;
-      var element = compile('<input ui-jq="foo">')(scope);
+      var element = compile('<input ui-jq="foo" ng-model="foobar">')(scope);
       element.bind('input', function(){
         bar = true;
       });
       element.trigger('change');
       expect(bar).toBe(true);
     });
-    it('should not watch a form control change event and trigger an input event if false', function() {
+    it('should ignore controls without ngModel attribute', function() {
       var bar = false;
-      var element = compile('<input ui-jq="foo" ui-options="{uiChange:false}">')(scope);
+      var element = compile('<input ui-jq="foo">')(scope);
       element.bind('input', function(){
         bar = true;
       });
       element.trigger('change');
       expect(bar).toBe(false);
     });
-    it('should not watch non-form controls', function() {
+    it('should ignore non-form controls', function() {
       var bar = false;
-      var element = compile('<div ui-jq="foo"></div>')(scope);
+      var element = compile('<div ui-jq="foo"></div  ng-model="foobar">')(scope);
       element.bind('input', function(){
         bar = true;
       });


### PR DESCRIPTION
Dropped uiChange, after doing some tests I confirmed that it cannot break anything by firing redundantly ('input' and 'change' events are always fired independently).

Added a uiRefresh property.
Added a uiDefer property/option for late-binding
