### PR TITLE
uiModal onShown and onHidden function callbacks, updated testing of modal closing

### DIFF
--- a/modules/directives/modal/modal.js
+++ b/modules/directives/modal/modal.js
@@ -6,8 +6,18 @@ angular.module('ui.directives')
     link: function(scope, elm, attrs, model) {
       //helper so you don't have to type class="modal hide"
       elm.addClass('modal hide');
+      var opts = angular.extend({}, scope.$eval(attrs.uiModal));
+
       elm.on( 'shown', function() {
         elm.find( "[autofocus]" ).focus();
+        if (angular.isFunction(opts.onShown)) {
+         opts.onShown();
+        }
+      });
+      elm.on( 'hidden', function() {
+        if (angular.isFunction(opts.onHidden)) {
+          opts.onHidden();
+        }
       });
       scope.$watch(attrs.ngModel, function(value) {
         elm.modal(value && 'show' || 'hide');

--- a/modules/directives/modal/test/modalSpec.js
+++ b/modules/directives/modal/test/modalSpec.js
@@ -1,22 +1,26 @@
 describe('modal', function () {
-  var elm, scope, $timeout;
+  var elm, scope, $timeout, $compile;
 
   beforeEach(module('ui.directives'));
 
-  beforeEach(inject(function ($injector, $rootScope, $compile) {
+  beforeEach(inject(function ($injector, $rootScope, _$compile_) {
     scope = $rootScope;
     $timeout = $injector.get('$timeout');
+    $compile = _$compile_;
+
     elm = $compile(
-      '<div ui-modal ng-model="modalShown">'
-    )($rootScope);
+        '<div ui-modal ng-model="modalShown">'
+    )(scope);
+
   }));
 
   it('should add "modal hide" class for you', function () {
     expect(elm.hasClass("modal hide")).toBe(true);
   });
 
-  describe('model change', function () {
-    it('should open modal', function () {
+  describe('unopened modal', function () {
+
+    it('should open modal on model change', function () {
       scope.$apply(function () {
         scope.modalShown = true;
       });
@@ -24,16 +28,6 @@ describe('modal', function () {
       expect(elm.hasClass('in')).toBe(true);
     });
 
-    it('should close modal', function () {
-      scope.$apply(function () {
-        scope.modalShown = false;
-      });
-      $timeout.flush();
-      expect(elm.hasClass('in')).toBe(false);
-    });
-  });
-
-  describe('open/close events', function () {
     it('should set model true when modal opens', function () {
       elm.modal('show');
       expect(scope.modalShown).toBeUndefined();
@@ -41,11 +35,54 @@ describe('modal', function () {
       expect(scope.modalShown).toBe(true);
     });
 
+  });
+
+  describe('opened modal', function () {
+    beforeEach(function () {
+      elm.modal('show');
+      $timeout.flush();
+    });
+
+    it('should close an open modal on model change', function () {
+      scope.$apply(function () {
+        scope.modalShown = false;
+      });
+      $timeout.flush();
+      expect(elm.hasClass('in')).toBe(false);
+    });
+
     it('should set model false when modal closes', function () {
       elm.modal('hide');
-      expect(scope.modalShown).toBeUndefined();
       $timeout.flush();
       expect(scope.modalShown).toBe(false);
     });
+
   });
+
+  describe('shown/hidden function', function () {
+    beforeEach(function() {
+      scope['shown'] = function () { };
+      scope['hidden'] = function () { };
+      spyOn(scope, 'shown');
+      spyOn(scope, 'hidden');
+
+      elm = $compile(
+          '<div ui-modal="{onShown:shown,onHidden:hidden}" ng-model="modalShown">'
+      )(scope);
+    });
+
+    it('should call onShown function when modal is shown', function () {
+      elm.modal('show');
+      $timeout.flush();
+      expect(scope.shown).toHaveBeenCalled();
+    });
+
+    it('should call onHidden function when open modal is hidden', function () {
+      elm.modal('show');
+      $timeout.flush();
+      elm.modal('hide');
+      $timeout.flush();
+      expect(scope.hidden).toHaveBeenCalled();
+    });
+  })
 });


### PR DESCRIPTION
...ring of shown and hidden events by bootstrap-modal.js

wire up by adding attribute value to ui-modal
e.g. ui-modal='{onShown:shownFn,onHidden:hiddenFn}'

updated ui-modal spec to make sure that the close tests take place after the modal has been opened first, otherwise they only confirm that the ui-modal hasn't been opened.
