### PR TITLE
Handle invalid masked setups more gracefully.

### DIFF
--- a/test/lib/maskedinput/jquery.maskedinput-1.3.js
+++ b/test/lib/maskedinput/jquery.maskedinput-1.3.js
@@ -54,7 +54,12 @@
 		mask: function(mask, settings) {
 			if (!mask && this.length > 0) {
 				var input = $(this[0]);
-				return input.data($.mask.dataName)();
+				var maskFn = input.data($.mask.dataName);
+				if (typeof maskFn !== 'function') {
+					console.error('maskedinput was not initialized correctly');
+					return;
+				}
+				return maskFn();
 			}
 			settings = $.extend({
 				placeholder: "_",


### PR DESCRIPTION
If there was a setup problem, i.e. you have <input ui-mask="99">, maskedinput stops here, because input.data($.mask.dataName) is undefined.
