### PR TITLE
Handle invalid masked setups more gracefully.

### DIFF
--- a/modules/directives/mask/test/maskSpec.js
+++ b/modules/directives/mask/test/maskSpec.js
@@ -35,4 +35,13 @@ xdescribe('uiMask', function () {
   describe('model binding on ui change', function () {
     //TODO: was having har time writing those tests, will open a separate issue for those
   });
+
+  describe('should fail', function() {
+    it('errors on missing quotes', function() {
+      $rootScope.x = 42;
+      var errorInputHtml = "<input ui-mask=\"(9)9\" ng-model='x'>";
+      element = $compile(errorInputHtml)($rootScope);
+      expect($rootScope.$digest()).toThrow();      
+    });
+  });
 });

--- a/test/lib/maskedinput/jquery.maskedinput-1.3.js
+++ b/test/lib/maskedinput/jquery.maskedinput-1.3.js
@@ -54,7 +54,11 @@
 		mask: function(mask, settings) {
 			if (!mask && this.length > 0) {
 				var input = $(this[0]);
-				return input.data($.mask.dataName)();
+				var maskFn = input.data($.mask.dataName);
+				if (typeof maskFn !== 'function') {
+					throw new Error('The Mask widget is not correctly set up');
+				}
+				return maskFn();
 			}
 			settings = $.extend({
 				placeholder: "_",


### PR DESCRIPTION
If the mask widget was not set up correctly, throw an Error with a hint.
