### PR TITLE
Updated Calendar to Utilize uiConfig for Event Callbacks 

### DIFF
--- a/modules/directives/calendar/calendar.js
+++ b/modules/directives/calendar/calendar.js
@@ -2,55 +2,61 @@
 *  AngularJs Fullcalendar Wrapper for the JQuery FullCalendar
 *  API @ http://arshaw.com/fullcalendar/ 
 *  
-*  Angular Calendar Directive that takes in the eventSources nested array object as the ng-model and watches an object named events for changes, 
+*  Angular Calendar Directive that takes in the eventSources nested array object as the ng-model and watches (eventSources.length + eventSources[i].length) for changes, 
 *  to update the view accordingly. Can also take in multiple event urls as a source object(s) and feed the events per view.
 *
 *
-*  The calendar must have an object named events on the scope to update itself properly when the events array is altered from outside of the calendar.  
+*  The calendar will watch any eventSource array and update itself when a delta is created  
 *
 */
 
 angular.module('ui.directives').directive('uiCalendar',['ui.config', '$parse', function (uiConfig,$parse) {
-    uiConfig.uiCalendar = uiConfig.uiCalendar || {};       
+     uiConfig.uiCalendar = uiConfig.uiCalendar || {};       
      //returns calendar     
      return {
         require: 'ngModel',
         restrict: 'A',
-         link: function(scope, elm, attrs) {
-            //update the calendar with the correct options
-            function update() {
-            var view;
-            if(elm.fullCalendar('getView')){
-              //setting the default view to be whatever the current view is. This can be overwritten. 
-              view = elm.fullCalendar('getView').name;
-            }
-            //If the calendar has options added then render them.
-            var expression,
-              options = {
-                defaultView : view,
-                eventSources: scope.$eval(attrs.ngModel)
-              };
-            if (attrs.uiCalendar) {
-              expression = scope.$eval(attrs.uiCalendar);
-                //if header has not been included then render default header options
-                if(!expression.hasOwnProperty('header')){
-                  expression.header = {
-                    left: 'prev,next today',
-                    center: 'title',
-                    right: 'month,agendaWeek,agendaDay'
-                  };
+          link: function(scope, elm, attrs, $timeout) {
+            var sources = scope.$eval(attrs.ngModel);
+            var tracker = 0;
+            /* returns the length of all source arrays plus the length of eventSource itself */
+            var getSources = function () {
+              tracker = 0;
+              angular.forEach(sources,function(value,key){
+                if(angular.isArray(value)){
+                  tracker += value.length;
                 }
-             } else {
-              expression = {};
-             }
-             angular.extend(options, uiConfig.uiCalendar, expression);
-             elm.html('').fullCalendar(options);
+              });
+              return tracker + sources.length;
+            };
+            /* update the calendar with the correct options */
+            function update() {
+              scope.calendar = elm.html('');
+              var view = scope.calendar.fullCalendar('getView');
+              //calendar object exposed on scope
+              if(view){
+                view = view.name; //setting the default view to be whatever the current view is. This can be overwritten. 
+              }
+              /* If the calendar has options added then render them */
+              var expression,
+                options = {
+                  defaultView : view,
+                  eventSources: sources
+                };
+              if (attrs.uiCalendar) {
+                expression = scope.$eval(attrs.uiCalendar);
+              } else {
+                expression = {};
+              }
+              angular.extend(options, uiConfig.uiCalendar, expression);
+              scope.calendar.fullCalendar(options);
             }
             update();
-            scope.$watch('events.length', function( newVal, oldVal )
-            {
-              update();
-            }, true );
-        }
+              /* watches all eventSources */
+              scope.$watch(getSources, function( newVal, oldVal )
+              {
+                update();
+              });
+         }
     };
 }]);

--- a/modules/directives/calendar/calendar.js
+++ b/modules/directives/calendar/calendar.js
@@ -19,9 +19,10 @@ angular.module('ui.directives').directive('uiCalendar',['ui.config', '$parse', f
          link: function(scope, elm, attrs) {
             //update the calendar with the correct options
             function update() {
+            var view;
             if(elm.fullCalendar('getView')){
               //setting the default view to be whatever the current view is. This can be overwritten. 
-              var view = elm.fullCalendar('getView').name;
+              view = elm.fullCalendar('getView').name;
             }
             //If the calendar has options added then render them.
             var expression,
@@ -37,7 +38,7 @@ angular.module('ui.directives').directive('uiCalendar',['ui.config', '$parse', f
                     left: 'prev,next today',
                     center: 'title',
                     right: 'month,agendaWeek,agendaDay'
-                  }
+                  };
                 }
              } else {
               expression = {};

--- a/modules/directives/calendar/test/calendarSpec.js
+++ b/modules/directives/calendar/test/calendarSpec.js
@@ -23,11 +23,25 @@ describe('uiCalendar', function () {
             {id: 999,title: 'Repeating Event',start: new Date(y, m, d - 3, 16, 0),allDay: false},
             {id: 999,title: 'Repeating Event',start: new Date(y, m, d + 4, 16, 0),allDay: true}];
 
-          //event Sources array  
-          scope.eventSources = [scope.events]; //End of Events Array
+          // create an array of events, to pass into the directive. 
+          scope.events2 = [
+            {title: 'All Day Event 2',start: new Date(y, m, 1),url: 'http://www.atlantacarlocksmith.com'},
+            {title: 'Long Event 2',start: new Date(y, m, d - 5),end: new Date(y, m, d - 2)},
+            {id: 998,title: 'Repeating Event 2',start: new Date(y, m, d - 3, 16, 0),allDay: false},
+            {id: 998,title: 'Repeating Event 2',start: new Date(y, m, d + 4, 16, 0),allDay: true}];
 
-          scope.addChild = function() {
-            scope.events.push({
+          // create an array of events, to pass into the directive. 
+          scope.events3 = [{title: 'All Day Event 3',start: new Date(y, m, 1),url: 'http://www.yoyoyo.com'}];
+
+          //event Sources array  
+          scope.eventSources = [scope.events,scope.events2]; //End of Events Array
+          
+          scope.addSource = function(source) {
+            scope.eventSources.push(source);
+          };
+
+          scope.addChild = function(array) {
+            array.push({
               title: 'Click for Google ' + scope.events.length,
               start: new Date(y, m, 28),
               end: new Date(y, m, 29),
@@ -35,9 +49,9 @@ describe('uiCalendar', function () {
             });
           };
 
-          scope.remove = function(index) {
-            scope.events.splice(index,1);
-           };
+          scope.remove = function(array,index) {
+            array.splice(index,1);
+          };
 
           scope.uiConfig = {
             calendar:{
@@ -56,70 +70,65 @@ describe('uiCalendar', function () {
     describe('compiling this directive and checking for events inside the calendar', function () {
 
 
-        //test the calendar's events length  
+        /* test the calendar's events length  */
         it('should excpect to load 4 events to scope', function () {
             spyOn($.fn, 'fullCalendar');
             $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
             expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length).toBe(4);
         });
-        //test to check the title of the first event. 
+        /* test to check the title of the first event. */
         it('should excpect to be All Day Event', function () {
             spyOn($.fn, 'fullCalendar');
             $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
             expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0][0].title).toBe('All Day Event');
         });
-        //test to make sure the event has a url assigned to it.
+        /* test to make sure the event has a url assigned to it. */
         it('should expect the url to = http://www.angularjs.org', function () {
             spyOn($.fn, 'fullCalendar');
             $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
             expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0][0].url).toBe('http://www.angularjs.org');
+            expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[1][0].url).toBe('http://www.atlantacarlocksmith.com');
         });
-        //test the 3rd events' allDay field.
+        /* test the 3rd events' allDay field. */
         it('should expect the fourth Events all Day field to equal true', function () {
             spyOn($.fn, 'fullCalendar');
             $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
             expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0][3].allDay).toNotBe(false);
         });
-        //Tests the height of the calendar.
+        /* Tests the height of the calendar. */
         it('should expect the calendar attribute height to be 200', function () {
             spyOn($.fn, 'fullCalendar');
             $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
             expect($.fn.fullCalendar.mostRecentCall.args[0].height).toEqual(200);  
         });
-        //Tests the weekends boolean of the calendar.
+        /* Tests the weekends boolean of the calendar. */
         it('should expect the calendar attribute weekends to be false', function () {
             spyOn($.fn, 'fullCalendar');
             $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
             expect($.fn.fullCalendar.mostRecentCall.args[0].weekends).toEqual(false);
         });
-        //Test to make sure that when an event is added to the calendar everything is updated with the new event.
+        /* Test to make sure that when an event is added to the calendar everything is updated with the new event. */
         it('should expect the scopes events to increase by 2', function () {
             spyOn($.fn, 'fullCalendar');
             $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
             expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length).toEqual(4);
-            scope.addChild();
-            scope.addChild();
+            scope.addChild(scope.events);
+            scope.addChild(scope.events);
             expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length).toEqual(6);
         });
-        //Test to make sure the calendar is updating itself on changes to events length.
+        /* Test to make sure the calendar is updating itself on changes to events length. */
         it('should expect the calendar to update itself with new events', function () {
             spyOn($.fn, 'fullCalendar');
             $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
             var clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length;
             expect(clientEventsLength).toEqual(4);
             //remove an event from the scope.
-            scope.remove(0);
+            scope.remove(scope.events,0);
             //events should auto update inside the calendar. 
             clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length;
             expect(clientEventsLength).toEqual(3);
         });
-        //Test to make sure header options are present if the user does not enter them
-        it('should have the header options even though they were not entered', function () {
-            spyOn($.fn, 'fullCalendar');
-            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
-            expect($.fn.fullCalendar.mostRecentCall.args[0].hasOwnProperty('header')).toEqual(true);
-        });
-        //Test to make sure header options can be overwritten
+        /* Test to make sure header options can be overwritten */
         it('should overwrite default header options', function () {
             spyOn($.fn, 'fullCalendar');
             scope.uiConfig2 = {
@@ -131,6 +140,41 @@ describe('uiCalendar', function () {
             expect($.fn.fullCalendar.mostRecentCall.args[0].hasOwnProperty('header')).toEqual(true);
             var header = $.fn.fullCalendar.mostRecentCall.args[0].header;
             expect(header).toEqual({center: 'title'});
+        });
+        /* Test to see if calendar is watching all eventSources for changes. */
+        it('should update the calendar if any eventSource array contains a delta', function () {
+            spyOn($.fn, 'fullCalendar');
+            $compile('<div ui-calendar="uiConfig2.calendar" ng-model="eventSources"></div>')(scope);
+            var clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length;
+            var clientEventsLength2 = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[1].length;
+            expect(clientEventsLength).toEqual(4);
+            expect(clientEventsLength2).toEqual(4);
+            //remove an event from the scope.
+            scope.remove(scope.events2,0);
+            //events should auto update inside the calendar. 
+            clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length;
+            clientEventsLength2 = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[1].length;
+            expect(clientEventsLength).toEqual(4);
+            expect(clientEventsLength2).toEqual(3);
+            scope.remove(scope.events,0);
+            clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length;
+            expect(clientEventsLength).toEqual(3);
+        });
+        /* Test to see if calendar is updating when a new eventSource is added. */
+        it('should update the calendar if an eventSource is Added', function () {
+            spyOn($.fn, 'fullCalendar');
+            $compile('<div ui-calendar="uiConfig2.calendar" ng-model="eventSources"></div>')(scope);
+            var clientEventSources = $.fn.fullCalendar.mostRecentCall.args[0].eventSources.length;
+            expect(clientEventSources).toEqual(2);
+            //add new source to calendar
+            scope.addSource(scope.events3);
+            //eventSources should auto update inside the calendar. 
+            clientEventSources = $.fn.fullCalendar.mostRecentCall.args[0].eventSources.length;
+            expect(clientEventSources).toEqual(3);
+            //go ahead and add some more events to the array and check those too.
+            scope.addChild(scope.events3);
+            var clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[2].length;
+            expect(clientEventsLength).toEqual(2);
         });
 
        });

--- a/modules/directives/calendar/test/calendarSpec.js
+++ b/modules/directives/calendar/test/calendarSpec.js
@@ -18,25 +18,13 @@ describe('uiCalendar', function () {
 
           // create an array of events, to pass into the directive. 
           scope.events = [
-            {
-              title: 'All Day Event',
-              start: new Date(y, m, 1),
-              url: 'http://www.angularjs.org'},
-            {
-              title: 'Long Event',
-              start: new Date(y, m, d - 5),
-              end: new Date(y, m, d - 2)},
-            {
-              id: 999,
-              title: 'Repeating Event',
-              start: new Date(y, m, d - 3, 16, 0),
-              allDay: false},
-            {
-              id: 999,
-              title: 'Repeating Event',
-              start: new Date(y, m, d + 4, 16, 0),
-              allDay: true}
-          ]; //End of Events Array
+            {title: 'All Day Event',start: new Date(y, m, 1),url: 'http://www.angularjs.org'},
+            {title: 'Long Event',start: new Date(y, m, d - 5),end: new Date(y, m, d - 2)},
+            {id: 999,title: 'Repeating Event',start: new Date(y, m, d - 3, 16, 0),allDay: false},
+            {id: 999,title: 'Repeating Event',start: new Date(y, m, d + 4, 16, 0),allDay: true}];
+
+          //event Sources array  
+          scope.eventSources = [scope.events]; //End of Events Array
 
           scope.addChild = function() {
             scope.events.push({
@@ -50,6 +38,14 @@ describe('uiCalendar', function () {
           scope.remove = function(index) {
             scope.events.splice(index,1);
            };
+
+          scope.uiConfig = {
+            calendar:{
+              height: 200,
+              weekends: false,
+              defaultView: 'month'
+           }
+          };
          
     }));
 
@@ -60,64 +56,81 @@ describe('uiCalendar', function () {
     describe('compiling this directive and checking for events inside the calendar', function () {
 
 
-        //test the calendars events length to be 4  
+        //test the calendar's events length  
         it('should excpect to load 4 events to scope', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
-            expect($.fn.fullCalendar.mostRecentCall.args[0].events.length).toBe(4);
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length).toBe(4);
         });
         //test to check the title of the first event. 
         it('should excpect to be All Day Event', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
-            expect($.fn.fullCalendar.mostRecentCall.args[0].events[0].title).toBe('All Day Event');
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0][0].title).toBe('All Day Event');
         });
         //test to make sure the event has a url assigned to it.
         it('should expect the url to = http://www.angularjs.org', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
-            expect($.fn.fullCalendar.mostRecentCall.args[0].events[0].url).toBe('http://www.angularjs.org');
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0][0].url).toBe('http://www.angularjs.org');
         });
         //test the 3rd events' allDay field.
         it('should expect the fourth Events all Day field to equal true', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
-            expect($.fn.fullCalendar.mostRecentCall.args[0].events[3].allDay).toNotBe(false);
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0][3].allDay).toNotBe(false);
         });
         //Tests the height of the calendar.
         it('should expect the calendar attribute height to be 200', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
-            //console.log('hello ' + $.fn.fullCalendar.mostRecentCall.args[0]);
-            expect($.fn.fullCalendar.mostRecentCall.args[0].height).toEqual(200);
-        
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].height).toEqual(200);  
         });
         //Tests the weekends boolean of the calendar.
         it('should expect the calendar attribute weekends to be false', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
             expect($.fn.fullCalendar.mostRecentCall.args[0].weekends).toEqual(false);
         });
         //Test to make sure that when an event is added to the calendar everything is updated with the new event.
         it('should expect the scopes events to increase by 2', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
-            expect($.fn.fullCalendar.mostRecentCall.args[0].events.length).toEqual(4);
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length).toEqual(4);
             scope.addChild();
             scope.addChild();
-            expect($.fn.fullCalendar.mostRecentCall.args[0].events.length).toEqual(6);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length).toEqual(6);
         });
         //Test to make sure the calendar is updating itself on changes to events length.
         it('should expect the calendar to update itself with new events', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
-            var clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].events.length;
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
+            var clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length;
             expect(clientEventsLength).toEqual(4);
             //remove an event from the scope.
             scope.remove(0);
             //events should auto update inside the calendar. 
-            clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].events.length;
+            clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length;
             expect(clientEventsLength).toEqual(3);
+        });
+        //Test to make sure header options are present if the user does not enter them
+        it('should have the header options even though they were not entered', function () {
+            spyOn($.fn, 'fullCalendar');
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].hasOwnProperty('header')).toEqual(true);
+        });
+        //Test to make sure header options can be overwritten
+        it('should overwrite default header options', function () {
+            spyOn($.fn, 'fullCalendar');
+            scope.uiConfig2 = {
+              calendar:{
+                header: {center: 'title'} 
+             }
+            };
+            $compile('<div ui-calendar="uiConfig2.calendar" ng-model="eventSources"></div>')(scope);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].hasOwnProperty('header')).toEqual(true);
+            var header = $.fn.fullCalendar.mostRecentCall.args[0].header;
+            expect(header).toEqual({center: 'title'});
         });
 
        });


### PR DESCRIPTION
The calendar was utilizing an isolated scope to take in the events. This was not good for communication between the calendar and the scope's event objects. We need to evaluate the events from the ng-model attribute so that scope functions can be wired to the calendar's event callbacks.

There has been one major change to the api of the calendar. We are now taking in the eventSources through ngModel so that an event array of objects and arrays of source objects can be added at the same time. 

Now the events object that is added into ng-model needs to be structured as a nested array. This is all documented here http://arshaw.com/fullcalendar/docs/event_data/eventSources/

We are still requiring ng-model so that the calendar cannot be created without an events array of individual event objects. 

We are detecting whether or not the user has created header options for the calendar and if so we use those instead of the defaults. 
