### PR TITLE
fix(ieshiv): Removed browser version check and closes #392

### DIFF
--- a/common/ieshiv/ieshiv.js
+++ b/common/ieshiv/ieshiv.js
@@ -24,21 +24,7 @@
   window.myCustomTags =  window.myCustomTags || []; // externally defined by developer using angular-ui directives
   tags.push.apply(tags, window.myCustomTags);
 
-  var getIE = function () {
-    // Returns the version of Internet Explorer or a -1
-    // (indicating the use of another browser).
-    var rv = -1; // Return value assumes failure.
-    if (navigator.appName == 'Microsoft Internet Explorer') {
-      var ua = navigator.userAgent;
-      var re = new RegExp("MSIE ([0-9]{1,}[\\.0-9]{0,})");
-      if (re.exec(ua) !== null) {
-        rv = parseFloat(RegExp.$1);
-      }
-    }
-    return rv;
-  };
-
-  var toCustomElements = function (str, delim) {
+  var toCustomElements = function (str) {
     var result = [];
     var dashed = str.replace(/([A-Z])/g, function ($1) {
       return " " + $1.toLowerCase();
@@ -55,20 +41,12 @@
     return result;
   };
 
-  var shiv = function () {
-    for (var i = 0, tlen = tags.length; i < tlen; i++) {
-      var customElements = toCustomElements(tags[i], ':');
-      for (var j = 0, clen = customElements.length; j < clen; j++) {
-        var customElement = customElements[j];
-        document.createElement(customElement);
-      }
+  for (var i = 0, tlen = tags.length; i < tlen; i++) {
+    var customElements = toCustomElements(tags[i]);
+    for (var j = 0, clen = customElements.length; j < clen; j++) {
+      var customElement = customElements[j];
+      document.createElement(customElement);
     }
-  };
-
-  var ieVersion = getIE();
-
-  if ((ieVersion > -1 && ieVersion < 9) || debug) {
-    shiv();
   }
 
 })(window);


### PR DESCRIPTION
Since it's impossible to load this asset asynchronously there isn't really a reason to put the checks in js either.
