### PR TITLE
Re-Wrote Calendar to Watch All Event Sources

### DIFF
--- a/modules/directives/calendar/calendar.js
+++ b/modules/directives/calendar/calendar.js
@@ -1,63 +1,66 @@
 /*
 *  AngularJs Fullcalendar Wrapper for the JQuery FullCalendar
-*  inspired by http://arshaw.com/fullcalendar/ 
+*  API @ http://arshaw.com/fullcalendar/ 
 *  
-*  Basic Angular Calendar Directive that takes in live events as the ng-model and watches that event array for changes, to update the view accordingly. 
-*  Can also take in an event url as a source object(s) and feed the events per view. 
+*  Angular Calendar Directive that takes in the eventSources nested array object as the ng-model and watches (eventSources.length + eventSources[i].length) for changes, 
+*  to update the view accordingly. Can also take in multiple event urls as a source object(s) and feed the events per view.
+*
+*
+*  The calendar will watch any eventSource array and update itself when a delta is created  
 *
 */
 
 angular.module('ui.directives').directive('uiCalendar',['ui.config', '$parse', function (uiConfig,$parse) {
-    uiConfig.uiCalendar = uiConfig.uiCalendar || {};       
-    //returns the fullcalendar     
-    return {
+     uiConfig.uiCalendar = uiConfig.uiCalendar || {};       
+     //returns calendar     
+     return {
         require: 'ngModel',
         restrict: 'A',
-        scope: {
-          events: "=ngModel"
-        },
-        link: function(scope, elm, $attrs) {
-            var ngModel = $parse($attrs.ngModel);
-            //update method that is called on load and whenever the events array is changed. 
+          link: function(scope, elm, attrs, $timeout) {
+            var sources = scope.$eval(attrs.ngModel);
+            var tracker = 0;
+            /* returns the length of all source arrays plus the length of eventSource itself */
+            var getSources = function () {
+              tracker = 0;
+              angular.forEach(sources,function(value,key){
+                if(angular.isArray(value)){
+                  tracker += value.length;
+                }
+              });
+               if(angular.isNumber(equalsTracker)){
+                return tracker + sources.length + equalsTracker;
+               }else{
+                return tracker + sources.length;
+              }
+            };
+            /* update the calendar with the correct options */
             function update() {
-              //Default View Options
+              scope.calendar = elm.html('');
+              var view = scope.calendar.fullCalendar('getView');
+              //calendar object exposed on scope
+              if(view){
+                view = view.name; //setting the default view to be whatever the current view is. This can be overwritten. 
+              }
+              /* If the calendar has options added then render them */
               var expression,
                 options = {
-                  header: {
-                  left: 'prev,next today',
-                  center: 'title',
-                  right: 'month,agendaWeek,agendaDay'
-                },
-              // add event name to title attribute on mouseover. 
-              eventMouseover: function(event, jsEvent, view) {
-              if (view.name !== 'agendaDay') {
-                $(jsEvent.target).attr('title', event.title);
-               }
-              },
-          
-              // Calling the events from the scope through the ng-model binding attribute. 
-              events: scope.events
-              };          
-              //if attrs have been entered to the directive, then create a relative expression. 
-              if ($attrs.uiCalendar){
-                 expression = scope.$eval($attrs.uiCalendar);
-              }
-              else{
+                  defaultView : view,
+                  eventSources: sources
+                };
+              if (attrs.uiCalendar) {
+                expression = scope.$eval(attrs.uiCalendar);
+              } else {
                 expression = {};
-              } 
-              //extend the options to suite the custom directive.
+              }
               angular.extend(options, uiConfig.uiCalendar, expression);
-              //call fullCalendar from an empty html tag, to keep angular happy.
-              elm.html('').fullCalendar(options);
+              scope.calendar.fullCalendar(options);
             }
-            //on load update call.
             update();
-            //watching the length of the array to create a more efficient update process. 
-            scope.$watch( 'events.length', function( newVal, oldVal )
-            {
-              //update the calendar on every change to events.length
-              update();
-            });
-        }
+              /* watches all eventSources */
+              scope.$watch(getSources, function( newVal, oldVal )
+              {
+                update();
+              });
+         }
     };
 }]);

--- a/modules/directives/calendar/calendar.js
+++ b/modules/directives/calendar/calendar.js
@@ -2,11 +2,10 @@
 *  AngularJs Fullcalendar Wrapper for the JQuery FullCalendar
 *  API @ http://arshaw.com/fullcalendar/ 
 *  
-*  Angular Calendar Directive that takes in the eventSources nested array object as the ng-model and watches (eventSources.length + eventSources[i].length) for changes, 
-*  to update the view accordingly. Can also take in multiple event urls as a source object(s) and feed the events per view.
-*
-*
-*  The calendar will watch any eventSource array and update itself when a delta is created  
+*  Angular Calendar Directive that takes in the [eventSources] nested array object as the ng-model and watches (eventSources.length + eventSources[i].length) for changes. 
+*       Can also take in multiple event urls as a source object(s) and feed the events per view.
+*       The calendar will watch any eventSource array and update itself when a delta is created  
+*       An equalsTracker attrs has been added for use cases that would render the overall length tracker the same even though the events have changed to force updates.
 *
 */
 
@@ -35,9 +34,9 @@ angular.module('ui.directives').directive('uiCalendar',['ui.config', '$parse', f
             };
             /* update the calendar with the correct options */
             function update() {
+              //calendar object exposed on scope
               scope.calendar = elm.html('');
               var view = scope.calendar.fullCalendar('getView');
-              //calendar object exposed on scope
               if(view){
                 view = view.name; //setting the default view to be whatever the current view is. This can be overwritten. 
               }

--- a/modules/directives/calendar/test/calendarSpec.js
+++ b/modules/directives/calendar/test/calendarSpec.js
@@ -18,28 +18,30 @@ describe('uiCalendar', function () {
 
           // create an array of events, to pass into the directive. 
           scope.events = [
-            {
-              title: 'All Day Event',
-              start: new Date(y, m, 1),
-              url: 'http://www.angularjs.org'},
-            {
-              title: 'Long Event',
-              start: new Date(y, m, d - 5),
-              end: new Date(y, m, d - 2)},
-            {
-              id: 999,
-              title: 'Repeating Event',
-              start: new Date(y, m, d - 3, 16, 0),
-              allDay: false},
-            {
-              id: 999,
-              title: 'Repeating Event',
-              start: new Date(y, m, d + 4, 16, 0),
-              allDay: true}
-          ]; //End of Events Array
+            {title: 'All Day Event',start: new Date(y, m, 1),url: 'http://www.angularjs.org'},
+            {title: 'Long Event',start: new Date(y, m, d - 5),end: new Date(y, m, d - 2)},
+            {id: 999,title: 'Repeating Event',start: new Date(y, m, d - 3, 16, 0),allDay: false},
+            {id: 999,title: 'Repeating Event',start: new Date(y, m, d + 4, 16, 0),allDay: true}];
 
-          scope.addChild = function() {
-            scope.events.push({
+          // create an array of events, to pass into the directive. 
+          scope.events2 = [
+            {title: 'All Day Event 2',start: new Date(y, m, 1),url: 'http://www.atlantacarlocksmith.com'},
+            {title: 'Long Event 2',start: new Date(y, m, d - 5),end: new Date(y, m, d - 2)},
+            {id: 998,title: 'Repeating Event 2',start: new Date(y, m, d - 3, 16, 0),allDay: false},
+            {id: 998,title: 'Repeating Event 2',start: new Date(y, m, d + 4, 16, 0),allDay: true}];
+
+          // create an array of events, to pass into the directive. 
+          scope.events3 = [{title: 'All Day Event 3',start: new Date(y, m, 1),url: 'http://www.yoyoyo.com'}];
+
+          //event Sources array  
+          scope.eventSources = [scope.events,scope.events2]; //End of Events Array
+          
+          scope.addSource = function(source) {
+            scope.eventSources.push(source);
+          };
+
+          scope.addChild = function(array) {
+            array.push({
               title: 'Click for Google ' + scope.events.length,
               start: new Date(y, m, 28),
               end: new Date(y, m, 29),
@@ -47,9 +49,17 @@ describe('uiCalendar', function () {
             });
           };
 
-          scope.remove = function(index) {
-            scope.events.splice(index,1);
-           };
+          scope.remove = function(array,index) {
+            array.splice(index,1);
+          };
+
+          scope.uiConfig = {
+            calendar:{
+              height: 200,
+              weekends: false,
+              defaultView: 'month'
+           }
+          };
          
     }));
 
@@ -60,64 +70,111 @@ describe('uiCalendar', function () {
     describe('compiling this directive and checking for events inside the calendar', function () {
 
 
-        //test the calendars events length to be 4  
+        /* test the calendar's events length  */
         it('should excpect to load 4 events to scope', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
-            expect($.fn.fullCalendar.mostRecentCall.args[0].events.length).toBe(4);
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length).toBe(4);
         });
-        //test to check the title of the first event. 
+        /* test to check the title of the first event. */
         it('should excpect to be All Day Event', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
-            expect($.fn.fullCalendar.mostRecentCall.args[0].events[0].title).toBe('All Day Event');
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0][0].title).toBe('All Day Event');
         });
-        //test to make sure the event has a url assigned to it.
+        /* test to make sure the event has a url assigned to it. */
         it('should expect the url to = http://www.angularjs.org', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
-            expect($.fn.fullCalendar.mostRecentCall.args[0].events[0].url).toBe('http://www.angularjs.org');
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0][0].url).toBe('http://www.angularjs.org');
+            expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[1][0].url).toBe('http://www.atlantacarlocksmith.com');
         });
-        //test the 3rd events' allDay field.
+        /* test the 3rd events' allDay field. */
         it('should expect the fourth Events all Day field to equal true', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
-            expect($.fn.fullCalendar.mostRecentCall.args[0].events[3].allDay).toNotBe(false);
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0][3].allDay).toNotBe(false);
         });
-        //Tests the height of the calendar.
+        /* Tests the height of the calendar. */
         it('should expect the calendar attribute height to be 200', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
-            //console.log('hello ' + $.fn.fullCalendar.mostRecentCall.args[0]);
-            expect($.fn.fullCalendar.mostRecentCall.args[0].height).toEqual(200);
-        
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].height).toEqual(200);  
         });
-        //Tests the weekends boolean of the calendar.
+        /* Tests the weekends boolean of the calendar. */
         it('should expect the calendar attribute weekends to be false', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
             expect($.fn.fullCalendar.mostRecentCall.args[0].weekends).toEqual(false);
         });
-        //Test to make sure that when an event is added to the calendar everything is updated with the new event.
+        /* Test to make sure that when an event is added to the calendar everything is updated with the new event. */
         it('should expect the scopes events to increase by 2', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
-            expect($.fn.fullCalendar.mostRecentCall.args[0].events.length).toEqual(4);
-            scope.addChild();
-            scope.addChild();
-            expect($.fn.fullCalendar.mostRecentCall.args[0].events.length).toEqual(6);
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length).toEqual(4);
+            scope.addChild(scope.events);
+            scope.addChild(scope.events);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length).toEqual(6);
         });
-        //Test to make sure the calendar is updating itself on changes to events length.
+        /* Test to make sure the calendar is updating itself on changes to events length. */
         it('should expect the calendar to update itself with new events', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div id="uicalendar" ui-calendar="{height: 200, weekends: false}" ng-model="events"></div>')(scope);
-            var clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].events.length;
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
+            var clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length;
             expect(clientEventsLength).toEqual(4);
             //remove an event from the scope.
-            scope.remove(0);
+            scope.remove(scope.events,0);
             //events should auto update inside the calendar. 
-            clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].events.length;
+            clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length;
             expect(clientEventsLength).toEqual(3);
+        });
+        /* Test to make sure header options can be overwritten */
+        it('should overwrite default header options', function () {
+            spyOn($.fn, 'fullCalendar');
+            scope.uiConfig2 = {
+              calendar:{
+                header: {center: 'title'} 
+             }
+            };
+            $compile('<div ui-calendar="uiConfig2.calendar" ng-model="eventSources"></div>')(scope);
+            expect($.fn.fullCalendar.mostRecentCall.args[0].hasOwnProperty('header')).toEqual(true);
+            var header = $.fn.fullCalendar.mostRecentCall.args[0].header;
+            expect(header).toEqual({center: 'title'});
+        });
+        /* Test to see if calendar is watching all eventSources for changes. */
+        it('should update the calendar if any eventSource array contains a delta', function () {
+            spyOn($.fn, 'fullCalendar');
+            $compile('<div ui-calendar="uiConfig2.calendar" ng-model="eventSources"></div>')(scope);
+            var clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length;
+            var clientEventsLength2 = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[1].length;
+            expect(clientEventsLength).toEqual(4);
+            expect(clientEventsLength2).toEqual(4);
+            //remove an event from the scope.
+            scope.remove(scope.events2,0);
+            //events should auto update inside the calendar. 
+            clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length;
+            clientEventsLength2 = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[1].length;
+            expect(clientEventsLength).toEqual(4);
+            expect(clientEventsLength2).toEqual(3);
+            scope.remove(scope.events,0);
+            clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length;
+            expect(clientEventsLength).toEqual(3);
+        });
+        /* Test to see if calendar is updating when a new eventSource is added. */
+        it('should update the calendar if an eventSource is Added', function () {
+            spyOn($.fn, 'fullCalendar');
+            $compile('<div ui-calendar="uiConfig2.calendar" ng-model="eventSources"></div>')(scope);
+            var clientEventSources = $.fn.fullCalendar.mostRecentCall.args[0].eventSources.length;
+            expect(clientEventSources).toEqual(2);
+            //add new source to calendar
+            scope.addSource(scope.events3);
+            //eventSources should auto update inside the calendar. 
+            clientEventSources = $.fn.fullCalendar.mostRecentCall.args[0].eventSources.length;
+            expect(clientEventSources).toEqual(3);
+            //go ahead and add some more events to the array and check those too.
+            scope.addChild(scope.events3);
+            var clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[2].length;
+            expect(clientEventsLength).toEqual(2);
         });
 
        });


### PR DESCRIPTION
Many updates to the calendar have ensued in the last month. 
1. The calendar is attached to the scope so that any method can be called from a controller at any time.
2. We are using the eventSources field instead of events, so that more than one source obj can be added to the calendar at once.
3. Every Array length inside of eventSources is being watched for changes. 
4. The view is updated to be the current view on every update, so that the calendar does not switch back to the default view any time the watch is fired.
5. equalsTracker attrs has been added to force the calendar to update on use cases that render the total eventSources length equal.
6. Rewrote and added tests to accompany each breaking change. 
