### PR TITLE
Add the jQuery UI Autocomplete wrapper

### DIFF
--- a/modules/directives/autocomplete/README.md
+++ b/modules/directives/autocomplete/README.md
@@ -1,0 +1,36 @@
+# ui-autocomplete directive
+
+This directive allows you to add an autocomplete to your form elements.
+
+Some details on my [blog](http://sharepointkunskap.wordpress.com/2013/01/04/angular-jquery-ui-autocomplete/)
+
+# Requirements
+
+- JQuery
+- JQueryUI
+
+# Usage
+
+Load the script file in your application:
+
+    <script type="text/javascript" src="angular-ui.js"></script>
+
+Add the date module as a dependency to your application module:
+
+    var myAppModule = angular.module('MyApp', ['ui.directives'])
+
+Apply the directive to your form elements:
+
+    <input ui-autocomplete="autocompleteOptions"></input>
+
+## Options
+
+All the jQueryUI Autocomplete options can be passed through the directive.
+
+	myAppModule.controller('MyController', function($scope) {
+		$scope.autocompleteOptions = {
+			changeYear: true,
+			changeMonth: true,
+			yearRange: '1900:-0'
+		};
+	});

--- a/modules/directives/autocomplete/autocomplete.js
+++ b/modules/directives/autocomplete/autocomplete.js
@@ -1,0 +1,31 @@
+/*global angular */
+/*
+ jQuery UI Autocomplete plugin wrapper
+ @author Anatoly Mironov
+ http://sharepointkunskap.wordpress.com, http://www.bool.se
+
+ @param [ui-autocomplete] {object} Options to pass to $.fn.autocomplete() 
+ */
+
+angular.module('ui.directives')
+
+.directive('uiAutocomplete', [function() {
+  var directive = {
+		require: '?ngModel',
+		link: function(scope, element, attrs, controller) {
+			var getOptions = function() {
+				return angular.extend({}, scope.$eval(attrs.uiAutocomplete));
+			};
+			var initAutocompleteWidget = function () {
+				var opts = getOptions();
+				element.autocomplete(opts);
+				if (opts._renderItem) {
+					element.data("autocomplete")._renderItem = opts._renderItem;
+				}
+			};
+			// Watch for changes to the directives options
+			scope.$watch(getOptions, initAutocompleteWidget, true);
+		}
+	};
+  return directive;
+}]);

--- a/modules/directives/autocomplete/autocomplete.js
+++ b/modules/directives/autocomplete/autocomplete.js
@@ -9,22 +9,23 @@
 
 angular.module('ui.directives')
 
-.directive('uiAutocomplete', [function() {
+.directive('uiAutocomplete', ['ui.config', function(uiConfig) {
   var directive = {
 		require: '?ngModel',
 		link: function(scope, element, attrs, controller) {
-			var getOptions = function() {
-				return angular.extend({}, scope.$eval(attrs.uiAutocomplete));
-			};
+			var options = {};
+			if (uiConfig.autocomplete) {
+				angular.extend(options, uiConfig.autocomplete);
+			}
 			var initAutocompleteWidget = function () {
-				var opts = getOptions();
+				var opts = angular.extend({}, options, scope.$eval(attrs.uiAutocomplete));
 				element.autocomplete(opts);
 				if (opts._renderItem) {
 					element.data("autocomplete")._renderItem = opts._renderItem;
 				}
 			};
 			// Watch for changes to the directives options
-			scope.$watch(getOptions, initAutocompleteWidget, true);
+			scope.$watch(attrs.uiAutocomplete, initAutocompleteWidget, true);
 		}
 	};
   return directive;

--- a/modules/directives/autocomplete/dependencies.json
+++ b/modules/directives/autocomplete/dependencies.json
@@ -1,0 +1,5 @@
+{
+    "core": [ "jquery", "jquery-ui" ],
+    "internal": [],
+    "external": []
+}

--- a/modules/directives/autocomplete/test/autocompleteSpec.js
+++ b/modules/directives/autocomplete/test/autocompleteSpec.js
@@ -1,5 +1,27 @@
 /*global describe, beforeEach, it, inject, expect, module, $*/
-describe('uiDate', function() {
+describe('uiAutocomplete', function() {
   'use strict';
-  //to be added
+  var source = ["javascript", "ruby", "c#", "haskell"];
+  var options = {
+	source: source
+  }
+  beforeEach(module('ui.directives'));
+  describe('simple use on input element', function() {
+    it('should have an autocomplete attached', function() {
+      inject(function($compile, $rootScope) {
+        var element;
+        element = $compile("<input ui-autocomplete/>")($rootScope);
+        expect(element.autocomplete()).toBeDefined();
+      });
+    });
+	it('should update autocomplete term when the element value is changed', function() {
+      inject(function($compile, $rootScope) {
+        var term, element;
+		term = "j";
+        element = $compile("<input ui-autocomplete='{\"source\": [\"hej\"]}' ng-model='x'/>")($rootScope);
+		element.val(term);
+        expect(element.data("autocomplete").term).toEqual(term);
+      });
+    });
+  });
 });

--- a/modules/directives/autocomplete/test/autocompleteSpec.js
+++ b/modules/directives/autocomplete/test/autocompleteSpec.js
@@ -1,0 +1,5 @@
+/*global describe, beforeEach, it, inject, expect, module, $*/
+describe('uiDate', function() {
+  'use strict';
+  //to be added
+});


### PR DESCRIPTION
Hi! I have seen many implementations of jQuery UI Autocomplete in angular UI, but there are no complete implementations. Here is the code for the autocomplete which can use all the options you can pass into a jQuery UI autocomplete. See my blog post for details: [angular jQuery UI autocomplete](http://sharepointkunskap.wordpress.com/2013/01/04/angular-jquery-ui-autocomplete/)
