### PR TITLE
Added keep-masked option.

### DIFF
--- a/modules/directives/mask/mask.js
+++ b/modules/directives/mask/mask.js
@@ -29,7 +29,11 @@ angular.module('ui.directives').directive('uiMask', [
          */
         element.bind('keyup', function () {
           $scope.$apply(function () {
-            controller.$setViewValue(element.mask());
+            if (element.data('keep-masked')) {
+              controller.$setViewValue(element.val());
+            } else {
+              controller.$setViewValue(element.mask());
+            }            
           });
         });
       }


### PR DESCRIPTION
Sometimes we need to get the masked value of an input, such as a date "10/12/2012".

In this case just add data-keep-mask="true" in the input.
