### PR TITLE
Fix UI refresh on programmatic change

### DIFF
--- a/modules/directives/select2/select2.js
+++ b/modules/directives/select2/select2.js
@@ -65,6 +65,10 @@ angular.module('ui.directives').directive('uiSelect2', ['ui.config', '$timeout',
                 }
               }
             }
+
+            $timeout(function () {
+              elm.trigger('change');
+            });
           };
 
           // Watch the options dataset for changes


### PR DESCRIPTION
On model variable change, the UI doesn't get the change because the trigger call is missing.
