### PR TITLE
Fix broken ui-validate-watch for retroactive dependencies

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "author": "AngularUI Team",
   "name": "angular-ui",
   "description": "AngularUI - Companion Suite for AngularJS",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "homepage": "http://angular-ui.github.com",
   "repository": {
     "type": "git",

--- a/modules/directives/validate/validate.js
+++ b/modules/directives/validate/validate.js
@@ -20,7 +20,7 @@ angular.module('ui.directives').directive('uiValidate', function () {
     restrict: 'A',
     require: 'ngModel',
     link: function (scope, elm, attrs, ctrl) {
-      var validateFn, watch, validators = {},
+      var validateFn, watches, validators = {},
         validateExpr = scope.$eval(attrs.uiValidate);
 
       if (!validateExpr) return;
@@ -46,20 +46,15 @@ angular.module('ui.directives').directive('uiValidate', function () {
 
       // Support for ui-validate-watch
       if (attrs.uiValidateWatch) {
-        watch = scope.$eval(attrs.uiValidateWatch);
-        if (angular.isString(watch)) {
-          scope.$watch(watch, function(){
-            angular.forEach(validators, function(validatorFn, key){
-              validatorFn(ctrl.$modelValue);
-            });
-          });
-        } else {
-          angular.forEach(watch, function(expression, key){
-            scope.$watch(expression, function(){
-              validators[key](ctrl.$modelValue);
-            });
-          });
+        watches = scope.$eval(attrs.uiValidateWatch);
+        if (angular.isString(watches)) {
+          watches = [ watches ];
         }
+        angular.forEach(watches, function(watch, key) {
+          scope.$watch(watch, function() {
+            ctrl.$setViewValue(ctrl.$viewValue);
+          });
+        });
       }
     }
   };

--- a/modules/directives/validate/validate.js
+++ b/modules/directives/validate/validate.js
@@ -46,14 +46,8 @@ angular.module('ui.directives').directive('uiValidate', function () {
 
       // Support for ui-validate-watch
       if (attrs.uiValidateWatch) {
-        watches = scope.$eval(attrs.uiValidateWatch);
-        if (angular.isString(watches)) {
-          watches = [ watches ];
-        }
-        angular.forEach(watches, function(watch, key) {
-          scope.$watch(watch, function() {
-            ctrl.$setViewValue(ctrl.$viewValue);
-          });
+        scope.$watch(attrs.uiValidateWatch, function() {
+          ctrl.$setViewValue(ctrl.$viewValue);
         });
       }
     }


### PR DESCRIPTION
In the `ui-angular-watch` implementation we should not re-validate against the `$modelValue` but the `$viewValue` of the field since : 
1. this is what angular naturally does ;
2. most of the time the `$modelValue` is `undefined` since angular values it if and only if the `$viewValue` is valid first.

The problem can be reproduced on the demo page by filling the `passwordConfirmation` first, and then the `password`. The `passwordConfirmation` stays invalid which is not expected.

The attached pull request fixes the problem by triggering again the natural angular validation process by simulating a change in the `$viewValue`

```
ctrl.$setViewValue(ctrl.$viewValue);
```

For instance, with this fix, the following cyclic five fields dependency schema works like a charm

```
A -> B -> C -> D -> E -> A
```
