### PR TITLE
fix(keypress): allow events to ommit key modifiers

### DIFF
--- a/modules/directives/keypress/keypress.js
+++ b/modules/directives/keypress/keypress.js
@@ -45,9 +45,9 @@ angular.module('ui.directives').factory('keypressHelper', ['$parse', function ke
     // Check only matching of pressed keys one of the conditions
     elm.bind(mode, function (event) {
       // No need to do that inside the cycle
-      var altPressed = event.metaKey || event.altKey;
-      var ctrlPressed = event.ctrlKey;
-      var shiftPressed = event.shiftKey;
+      var altPressed = event.metaKey || event.altKey || false;
+      var ctrlPressed = event.ctrlKey || false;
+      var shiftPressed = event.shiftKey || false;
       var keyCode = event.keyCode;
 
       // normalize keycodes

--- a/modules/directives/keypress/keypress.js
+++ b/modules/directives/keypress/keypress.js
@@ -45,9 +45,9 @@ angular.module('ui.directives').factory('keypressHelper', ['$parse', function ke
     // Check only matching of pressed keys one of the conditions
     elm.bind(mode, function (event) {
       // No need to do that inside the cycle
-      var altPressed = event.metaKey || event.altKey || false;
-      var ctrlPressed = event.ctrlKey || false;
-      var shiftPressed = event.shiftKey || false;
+      var altPressed = !!(event.metaKey || event.altKey);
+      var ctrlPressed = !!event.ctrlKey;
+      var shiftPressed = !!event.shiftKey;
       var keyCode = event.keyCode;
 
       // normalize keycodes
@@ -58,11 +58,11 @@ angular.module('ui.directives').factory('keypressHelper', ['$parse', function ke
       // Iterate over prepared combinations
       angular.forEach(combinations, function (combination) {
 
-        var mainKeyPressed = (combination.keys[keysByCode[event.keyCode]] || combination.keys[event.keyCode.toString()]) || false;
+        var mainKeyPressed = combination.keys[keysByCode[event.keyCode]] || combination.keys[event.keyCode.toString()];
 
-        var altRequired = combination.keys.alt || false;
-        var ctrlRequired = combination.keys.ctrl || false;
-        var shiftRequired = combination.keys.shift || false;
+        var altRequired = !!combination.keys.alt;
+        var ctrlRequired = !!combination.keys.ctrl;
+        var shiftRequired = !!combination.keys.shift;
 
         if (
           mainKeyPressed &&

--- a/modules/directives/keypress/test/keydownSpec.js
+++ b/modules/directives/keypress/test/keydownSpec.js
@@ -54,6 +54,14 @@ describe('uiKeydown', function () {
     expect($scope.event2).toBe(true);
   });
 
+  it('should support modifiers to be ommited from event', function () {
+    var keyEvent = jQuery.Event('keydown');
+    keyEvent.keyCode = 13;
+    createElement({'13': 'event=true'}).trigger(keyEvent);
+
+    expect($scope.event).toBe(true);
+  });
+
   it('should support $event in expressions', function () {
 
     var element = createElement({'esc': 'cb($event)', '13': 'event2=$event'});

--- a/modules/directives/keypress/test/keydownSpec.js
+++ b/modules/directives/keypress/test/keydownSpec.js
@@ -2,13 +2,13 @@ describe('uiKeydown', function () {
 
   var $scope, $compile;
 
-  var createKeyEvent = function (mainKey, alt, ctrl, shif) {
+  var createKeyEvent = function (mainKey, alt, ctrl, shift) {
     var keyEvent = jQuery.Event("keydown");
 
     keyEvent.keyCode = mainKey;
-    keyEvent.altKey = alt || false;
-    keyEvent.ctrlKey = ctrl || false;
-    keyEvent.shiftKey = shif || false;
+    keyEvent.altKey = alt;
+    keyEvent.ctrlKey = ctrl;
+    keyEvent.shiftKey = shift;
 
     return keyEvent;
   };
@@ -52,14 +52,6 @@ describe('uiKeydown', function () {
 
     elm.trigger(createKeyEvent(13, false, true, true));
     expect($scope.event2).toBe(true);
-  });
-
-  it('should support modifiers to be ommited from event', function () {
-    var keyEvent = jQuery.Event('keydown');
-    keyEvent.keyCode = 13;
-    createElement({'13': 'event=true'}).trigger(keyEvent);
-
-    expect($scope.event).toBe(true);
   });
 
   it('should support $event in expressions', function () {

--- a/modules/directives/keypress/test/keypressSpec.js
+++ b/modules/directives/keypress/test/keypressSpec.js
@@ -3,13 +3,13 @@ describe('uiKeypress', function () {
 
   var $scope, $compile;
 
-  var createKeyEvent = function (mainKey, alt, ctrl, shif) {
+  var createKeyEvent = function (mainKey, alt, ctrl, shift) {
     var keyEvent = jQuery.Event("keypress");
 
     keyEvent.keyCode = mainKey;
-    keyEvent.altKey = alt || false;
-    keyEvent.ctrlKey = ctrl || false;
-    keyEvent.shiftKey = shif || false;
+    keyEvent.altKey = alt;
+    keyEvent.ctrlKey = ctrl;
+    keyEvent.shiftKey = shift;
 
     return keyEvent;
   };
@@ -53,14 +53,6 @@ describe('uiKeypress', function () {
 
     elm.trigger(createKeyEvent(13, false, true, true));
     expect($scope.event2).toBe(true);
-  });
-
-  it('should support modifiers to be ommited from event', function () {
-    var keyEvent = jQuery.Event('keypress');
-    keyEvent.keyCode = 13;
-    createElement({'13': 'event=true'}).trigger(keyEvent);
-
-    expect($scope.event).toBe(true);
   });
 
   it('should support $event in expressions', function () {

--- a/modules/directives/keypress/test/keypressSpec.js
+++ b/modules/directives/keypress/test/keypressSpec.js
@@ -1,3 +1,4 @@
+
 describe('uiKeypress', function () {
 
   var $scope, $compile;
@@ -52,6 +53,14 @@ describe('uiKeypress', function () {
 
     elm.trigger(createKeyEvent(13, false, true, true));
     expect($scope.event2).toBe(true);
+  });
+
+  it('should support modifiers to be ommited from event', function () {
+    var keyEvent = jQuery.Event('keypress');
+    keyEvent.keyCode = 13;
+    createElement({'13': 'event=true'}).trigger(keyEvent);
+
+    expect($scope.event).toBe(true);
   });
 
   it('should support $event in expressions', function () {

--- a/modules/directives/keypress/test/keyupSpec.js
+++ b/modules/directives/keypress/test/keyupSpec.js
@@ -54,6 +54,14 @@ describe('uiKeyup', function () {
     expect($scope.event2).toBe(true);
   });
 
+  it('should support modifiers to be ommited from event', function () {
+    var keyEvent = jQuery.Event('keyup');
+    keyEvent.keyCode = 13;
+    createElement({'13': 'event=true'}).trigger(keyEvent);
+
+    expect($scope.event).toBe(true);
+  });
+
   it('should support $event in expressions', function () {
 
     var element = createElement({'esc': 'cb($event)', '13': 'event2=$event'});

--- a/modules/directives/keypress/test/keyupSpec.js
+++ b/modules/directives/keypress/test/keyupSpec.js
@@ -2,13 +2,13 @@ describe('uiKeyup', function () {
 
   var $scope, $compile;
 
-  var createKeyEvent = function (mainKey, alt, ctrl, shif) {
+  var createKeyEvent = function (mainKey, alt, ctrl, shift) {
     var keyEvent = jQuery.Event("keyup");
 
     keyEvent.keyCode = mainKey;
-    keyEvent.altKey = alt || false;
-    keyEvent.ctrlKey = ctrl || false;
-    keyEvent.shiftKey = shif || false;
+    keyEvent.altKey = alt;
+    keyEvent.ctrlKey = ctrl;
+    keyEvent.shiftKey = shift;
 
     return keyEvent;
   };
@@ -52,14 +52,6 @@ describe('uiKeyup', function () {
 
     elm.trigger(createKeyEvent(13, false, true, true));
     expect($scope.event2).toBe(true);
-  });
-
-  it('should support modifiers to be ommited from event', function () {
-    var keyEvent = jQuery.Event('keyup');
-    keyEvent.keyCode = 13;
-    createElement({'13': 'event=true'}).trigger(keyEvent);
-
-    expect($scope.event).toBe(true);
   });
 
   it('should support $event in expressions', function () {


### PR DESCRIPTION
Programmatically triggered events that do not include key modifiers (`altKey`, `shiftKey`, `ctrlKey`) properties would fail even when combination didn't require these keys.
