### PR TITLE
Fix for #434

### DIFF
--- a/modules/directives/route/route.js
+++ b/modules/directives/route/route.js
@@ -4,6 +4,7 @@
 angular.module('ui.directives').directive('uiRoute', ['$location', '$parse', function ($location, $parse) {
   return {
     restrict: 'AC',
+    scope: true,
     compile: function(tElement, tAttrs) {
       var useProperty;
       if (tAttrs.uiRoute) {

--- a/modules/directives/route/test/routeSpec.js
+++ b/modules/directives/route/test/routeSpec.js
@@ -24,12 +24,13 @@ describe('uiRoute', function () {
   });
 
   function runTests(routeModel) {
+    var modelProp = routeModel || '$uiRoute', elm = angular.noop;
     function compileRoute(template) {
-      var elm = $(template);
+      elm = $(template);
       if (routeModel) elm.attr('ng-model', routeModel);
       return $compile(elm[0])(scope);
     }
-    var modelProp = routeModel || '$uiRoute';
+    
     describe('with uiRoute defined', function(){
       it('should use the uiRoute property', function(){
         compileRoute('<div ui-route="/foo">');
@@ -38,16 +39,16 @@ describe('uiRoute', function () {
         setPath('/bar');
         scope.$apply('foobar = "foo"');
         compileRoute('<div ui-route="/{{foobar}}">');
-        expect(scope[modelProp]).toBeFalsy();
+        expect(elm.scope()[modelProp]).toBeFalsy();
         scope.$apply('foobar = "bar"');
-        expect(scope[modelProp]).toBe(true);
+        expect(elm.scope()[modelProp]).toBe(true);
         scope.$apply('foobar = "foo"');
-        expect(scope[modelProp]).toBe(false);
+        expect(elm.scope()[modelProp]).toBe(false);
       });
       it('should support regular expression', function(){
         setPath('/foo/123');
         compileRoute('<div ui-route="/foo/[0-9]*">');
-        expect(scope[modelProp]).toBe(true);
+        expect(elm.scope()[modelProp]).toBe(true);
       });
     });
 
@@ -56,17 +57,17 @@ describe('uiRoute', function () {
       it('should use the ngHref property', function(){
         setPath('/foo');
         compileRoute('<a ng-href="/foo" ui-route>');
-        expect(scope[modelProp]).toBe(true);
+        expect(elm.scope()[modelProp]).toBe(true);
       });
       it('should update model on $observe', function(){
         setPath('/bar');
         scope.$apply('foobar = "foo"');
         compileRoute('<a ng-href="/{{foobar}}" ui-route>');
-        expect(scope[modelProp]).toBeFalsy();
+        expect(elm.scope()[modelProp]).toBeFalsy();
         scope.$apply('foobar = "bar"');
-        expect(scope[modelProp]).toBe(true);
+        expect(elm.scope()[modelProp]).toBe(true);
         scope.$apply('foobar = "foo"');
-        expect(scope[modelProp]).toBe(false);
+        expect(elm.scope()[modelProp]).toBe(false);
       });
     });
 
@@ -75,7 +76,7 @@ describe('uiRoute', function () {
       it('should use the href property', function(){
         setPath('/foo');
         compileRoute('<a href="/foo" ui-route>');
-        expect(scope[modelProp]).toBe(true);
+        expect(elm.scope()[modelProp]).toBe(true);
       });
     });
 
@@ -88,11 +89,11 @@ describe('uiRoute', function () {
     it('should update model on route change', function(){
       setPath('/bar');
       compileRoute('<div ui-route="/foo">');
-      expect(scope[modelProp]).toBeFalsy();
+      expect(elm.scope()[modelProp]).toBeFalsy();
       setPath('/foo');
-      expect(scope[modelProp]).toBe(true);
+      expect(elm.scope()[modelProp]).toBe(true);
       setPath('/bar');
-      expect(scope[modelProp]).toBe(false);
+      expect(elm.scope()[modelProp]).toBe(false);
     });
   }
 });


### PR DESCRIPTION
Hey @ProLoser: 
I finally found a solution to fix the tests with scope = true for the ui-route directive. Note the multi scope support is not tested yet. I made some experiments with the following example which works fine if there is no ng-model defined but I was not able to integrate it without a big refactoring of the routeSpec...

<pre><code>
it('should support multiple scopes', function() {
      setPath('/foo');
      elm = $('&lt;ui&gt;&lt;li ui-route=&quot;/foo&quot;&gt;Foo&lt;/li&gt;&lt;li ui-route=&quot;/bar&quot;&gt;Bar&lt;/li&gt;&lt;/ul&gt;');
      $compile(elm[0])(scope);
      expect(elm.find('li').eq(0).scope()["modelProp"]).toBe(true);
      expect(elm.find('li').eq(1).scope()["modelProp"]).toBe(false);
      setPath('/bar');
      expect(elm.find('li').eq(0).scope()["modelProp"]).toBe(false);
      expect(elm.find('li').eq(1).scope()["modelProp"]).toBe(true);
    });
</code></pre>
