### PR TITLE
Angular-UI autocomplete wrapper

### DIFF
--- a/modules/directives/autocomplete/autocomplete.js
+++ b/modules/directives/autocomplete/autocomplete.js
@@ -21,15 +21,12 @@ angular.module('ui.directives')
         require: '?ngModel',
         link: function (scope, element, attrs, controller)
         {
-          var getOptions = function ()
-          {
-            var options = angular.extend({}, uiConfig.autocomplete, scope.$eval(attrs.uiAutocomplete));
-            return options;
-          };
 
           var initAutocomplete = function ()
           {
-            var opts = getOptions();
+            var opts = angular.extend(
+              {}, uiConfig.autocomplete, scope.$eval(attrs.uiAutocomplete)
+            );
 
             // If we have a controller (i.e. ngModelController) then wire it up
             if ( controller )
@@ -53,7 +50,7 @@ angular.module('ui.directives')
             element.autocomplete(opts);
           };
           // Watch for changes to the directives options
-          scope.$watch(getOptions, initAutocomplete, true);
+          scope.$watch(attrs.icAutocomplete, initAutocomplete, true);
         }
       };
     }

--- a/modules/directives/autocomplete/autocomplete.js
+++ b/modules/directives/autocomplete/autocomplete.js
@@ -35,7 +35,7 @@ angular.module('ui.directives')
                 if ( !scope.$$phase )
                 {
                   scope.$apply(function () {
-                    controller.$setViewValue(ui.item.value);
+                    controller.$setViewValue(ui.item);
                     element.blur();
                   });
                 }

--- a/modules/directives/autocomplete/autocomplete.js
+++ b/modules/directives/autocomplete/autocomplete.js
@@ -1,0 +1,62 @@
+/*global angular */
+/*
+jQuery UI Autocomplete plugin wrapper
+
+@param [ui-autocomplete] {object} Options to pass to $.fn.autocomplete() merged onto ui.config
+*/
+
+angular.module('ui.directives')
+
+.directive('uiAutocomplete',
+  [ 'ui.config',
+    function (uiConfig)
+    {
+      'use strict';
+      var options = {};
+      if ( angular.isObject(uiConfig.autocomplete) )
+      {
+        angular.extend(options, uiConfig.autocomplete);
+      }
+      return {
+        require: '?ngModel',
+        link: function (scope, element, attrs, controller)
+        {
+          var getOptions = function ()
+          {
+            var options = angular.extend({}, uiConfig.autocomplete, scope.$eval(attrs.uiAutocomplete));
+            return options;
+          };
+
+          var initAutocomplete = function ()
+          {
+            var opts = getOptions();
+
+            // If we have a controller (i.e. ngModelController) then wire it up
+            if ( controller )
+            {
+              var updateModel = function () {
+                if ( !scope.$$phase )
+                {
+                  scope.$apply(function () {
+                    var query = element.val();
+                    controller.$setViewValue(query);
+                    element.blur();
+                  });
+                }
+              }
+              
+              opts.select = updateModel;
+              // In case the user changes the text directly in the input box
+              element.bind('autocompleteselect', updateModel);
+            }
+            // Create the new autocomplete widget
+            element.autocomplete(opts);
+          };
+          // Watch for changes to the directives options
+          scope.$watch(getOptions, initAutocomplete, true);
+        }
+      };
+    }
+  ]
+);
+

--- a/modules/directives/autocomplete/autocomplete.js
+++ b/modules/directives/autocomplete/autocomplete.js
@@ -31,12 +31,11 @@ angular.module('ui.directives')
             // If we have a controller (i.e. ngModelController) then wire it up
             if ( controller )
             {
-              var updateModel = function () {
+              var updateModel = function (event, ui) {
                 if ( !scope.$$phase )
                 {
                   scope.$apply(function () {
-                    var query = element.val();
-                    controller.$setViewValue(query);
+                    controller.$setViewValue(ui.item.value);
                     element.blur();
                   });
                 }

--- a/modules/directives/map/README.md
+++ b/modules/directives/map/README.md
@@ -1,0 +1,95 @@
+# About
+
+This adds support for 2 google maps api3 plugins.
+
+## MarkerClustererPlus
+
+This provides a *significant* performance boost when it comes to dealing with a multitude of markers (making it possible to have thousands of markers): markers that are in close proximity are aggregated into a single cluster/group with the count of markers contained. Google Maps api3 has no native equivalent.
+
+[MarkerClustererPlus Project](http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/)
+
+### Important!!
+
+You **MUST** alter the [MCp](http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/src/markerclusterer.js) with the following (which does add a dependency on jQuery:
+
+(around line 667)
+```js
+- function MarkerClusterer(map, opt_markers, opt_options) {
++ function MarkerClusterer(map, opt_markers, opt_optionsG) {
+```
+
+and (around line 686)
+
+```js
+- opt_options = opt_options || {};
++ var opt_options = jQuery.extend(true, {}, opt_optionsG ) || {};
+```
+
+## InfoBox
+
+This is an easier to style alternative to the native InfoWindow.
+
+[InfoBox Project](http://google-maps-utility-library-v3.googlecode.com/svn/trunk/infobox/)
+
+# Use
+
+## Config
+```js
+app.value('ic.config',
+  {
+    "map": {
+      "clusters": {
+        "imagesDir": "path/to/img"
+      },
+      "infoBox": { … }, // native options, nothing new here
+      "map": { … } // native options, nothing new here
+    }
+  }
+);
+```
+
+## html
+
+```html
+<div
+  id="map_container"
+  class="view">
+
+  <div ui-if="mapReady">
+    
+    <div
+      id="map"
+      ic-map="map.map"
+      ic-options="map.options"
+    >
+      <div id="map_canvas"></div>
+      <div
+        ic-map-info-box="map.infoBox.one"
+        ic-options="{containerId:'infobox_one'}"
+      >
+        <div
+          id="infobox_one"
+          ng-include src="'path/to/template.html'"
+        ></div>
+        <div ic-map-markers="map.data.one"></div>
+
+      </div>
+
+      <div
+        ic-map-info-box="map.infoBox.two"
+        ic-options="{containerId:'infobox_two'}"
+      >
+        <div
+          id="infobox_two"
+          ng-include src="'path/to/otherTemplate.html'"
+        ></div>
+        <div
+          ic-map-clusters="map.data.two"
+          ic-options="map.data.two.options"
+          ng-model="markers.two"
+        ></div>
+
+    </div>
+
+</div>
+```

--- a/modules/directives/map/map.js
+++ b/modules/directives/map/map.js
@@ -1,97 +1,284 @@
 (function () {
   var app = angular.module('ui.directives');
 
-  //Setup map events from a google map object to trigger on a given element too,
-  //then we just use ui-event to catch events from an element
-  function bindMapEvents(scope, eventsStr, googleObject, element) {
-    angular.forEach(eventsStr.split(' '), function (eventName) {
+  // Setup map events from a google map object to trigger on a given element,
+  // then just use ui-event to catch events from an element
+  function bindMapEvents(scope, eventsStr, googleObject, element)
+  {
+    angular.forEach(eventsStr.split(' '), function (eventName)
+    {
       //Prefix all googlemap events with 'map-', so eg 'click' 
       //for the googlemap doesn't interfere with a normal 'click' event
       var $event = { type: 'map-' + eventName };
-      google.maps.event.addListener(googleObject, eventName, function (evt) {
+      google.maps.event.addListener(googleObject, eventName, function (evt)
+      {
         element.triggerHandler(angular.extend({}, $event, evt));
-        //We create an $apply if it isn't happening. we need better support for this
-        //We don't want to use timeout because tons of these events fire at once,
-        //and we only need one $apply
+        // We create an $apply if it isn't happening--needs better support.
+        // Don't want to use timeout because tons of these events fire at once,
+        // and we only need one $apply
         if (!scope.$$phase) scope.$apply();
       });
     });
   }
 
-  app.directive('uiMap',
-    ['ui.config', '$parse', function (uiConfig, $parse) {
+  app.directive('icMap',
+    ['ic.config', '$parse',
+      function (icConfig, $parse)
+      {
+        var mapEvents = 'bounds_changed center_changed click dblclick ' +
+          'drag dragend dragstart heading_changed idle maptypeid_changed ' +
+          'mousemove mouseout mouseover projection_changed resize rightclick ' +
+          'tilesloaded tilt_changed zoom_changed';
+        var options = icConfig.map || {};
 
-      var mapEvents = 'bounds_changed center_changed click dblclick drag dragend ' +
-        'dragstart heading_changed idle maptypeid_changed mousemove mouseout ' +
-        'mouseover projection_changed resize rightclick tilesloaded tilt_changed ' +
-        'zoom_changed';
-      var options = uiConfig.map || {};
-
-      return {
-        restrict: 'A',
-        //doesn't work as E for unknown reason
-        link: function (scope, elm, attrs) {
-          var opts = angular.extend({}, options, scope.$eval(attrs.uiOptions));
-          var map = new google.maps.Map(elm[0], opts);
-          var model = $parse(attrs.uiMap);
-
-          //Set scope variable for the map
-          model.assign(scope, map);
-
-          bindMapEvents(scope, mapEvents, map, elm);
+        function controller($scope, $element, $attrs)
+        {
+          var icOptions = $scope.$eval($attrs.icOptions);
+          this.opts = {
+            "clusters": angular.extend(
+                {}, options.clusters, icOptions.clusters
+              ),
+            "infoBox": angular.extend(
+                {}, options.infoBox, icOptions.infoBox
+              ),
+            "map": angular.extend(
+                {}, options.map, icOptions.map
+              ),
+            "markers": angular.extend(
+                {}, options.markers, icOptions.markers
+              )
+          };
+          $scope.mapId = this.opts.map.mapId || "map_canvas";
+          $scope.mapObj = {};
+          $scope.mapElm = {};
         }
-      };
-    }]);
 
-  app.directive('uiMapInfoWindow',
-    ['ui.config', '$parse', '$compile', function (uiConfig, $parse, $compile) {
+        function postLink(scope, elm, attrs, controllers)
+        {
+          var _opts = controllers[0].opts.map;
+          scope.mapElm = elm.find("#"+_opts.mapId);
+          scope.mapObj = new google.maps.Map(scope.mapElm[0], _opts);
+          var model = $parse(attrs.icMap);
+          
+          // Set scope variable for the map
+          model.assign(scope, scope.mapObj);
+          bindMapEvents(scope, mapEvents, scope.mapObj, scope.mapElm);
+        }
 
-      var infoWindowEvents = 'closeclick content_change domready ' +
-        'position_changed zindex_changed';
-      var options = uiConfig.mapInfoWindow || {};
+        return {
+          priority: 100,
+          restrict: 'A',
+          require: ['icMap'],
+          controller: controller,
+          link: postLink
+        };
+      }
+    ]
+  );
 
-      return {
-        link: function (scope, elm, attrs) {
-          var opts = angular.extend({}, options, scope.$eval(attrs.uiOptions));
-          opts.content = elm[0];
-          var model = $parse(attrs.uiMapInfoWindow);
-          var infoWindow = model(scope);
+  app.directive('icMapInfoBox',
+    ['ic.config','$parse', '$compile',
+      function (icConfig, $parse, $compile)
+      {
+        var infoBoxEvents = 'closeclick content_change domready ' +
+          'position_changed zindex_changed';
 
-          if (!infoWindow) {
-            infoWindow = new google.maps.InfoWindow(opts);
-            model.assign(scope, infoWindow);
+        function postLink(scope, elm, attrs, controllers)
+        {
+          var icOptions = scope.$eval(attrs.icOptions);
+          var _opts = angular.extend(
+            {}, controllers[0].opts.infoBox, icOptions
+          );
+          var model = $parse(attrs.icMapInfoBox);
+          scope.infoBoxObj = model(scope);
+          if ( ! angular.isDefined(_opts.containerId) )
+          { _opts.containerId = "infobox_container"; }
+          var infoboxElm = elm.find("#"+_opts.containerId);
+
+          if ( !scope.infoBoxObj )
+          {
+            scope.infoBoxObj = new InfoBox(_opts);
+            model.assign(scope, scope.infoBoxObj);
           }
+          bindMapEvents(scope, infoBoxEvents, scope.infoBoxObj, infoboxElm);
 
-          bindMapEvents(scope, infoWindowEvents, infoWindow, elm);
+          // Don't need infobox's template on the DOM anymore--now stored in
+          // google maps, so just replace the old element with an empty div.
+          //!\\ DO NOT remove it altogether because that can mess up angular
+          infoboxElm.replaceWith('<div></div>');
 
-          /* The info window's contents dont' need to be on the dom anymore,
-           google maps has them stored.  So we just replace the infowindow element
-           with an empty div. (we don't just straight remove it from the dom because
-           straight removing things from the dom can mess up angular) */
-          elm.replaceWith('<div></div>');
-
-          //Decorate infoWindow.open to $compile contents before opening
-          var _open = infoWindow.open;
-          infoWindow.open = function open(a1, a2, a3, a4, a5, a6) {
-            $compile(elm.contents())(scope);
-            _open.call(infoWindow, a1, a2, a3, a4, a5, a6);
+          // Decorate infoBox.open to $compile contents before opening
+          var _open = scope.infoBoxObj.open;
+          scope.infoBoxObj.open = function open(mapObj, markerObj)
+          {
+            scope.infoBoxObj.setContent( infoboxElm[0] );
+            _open.call(this, mapObj, markerObj);
           };
         }
-      };
-    }]);
 
-  /* 
-   * Map overlay directives all work the same. Take map marker for example
-   * <ui-map-marker="myMarker"> will $watch 'myMarker' and each time it changes,
-   * it will hook up myMarker's events to the directive dom element.  Then
-   * ui-event will be able to catch all of myMarker's events. Super simple.
-   */
-  function mapOverlayDirective(directiveName, events) {
+        return {
+          priority: 50,
+          restrict: 'A',
+          require: ['?^icMap'],
+          scope: true,
+          link: postLink
+        };
+      }
+    ]
+  );
+
+  function addMarkers(map, markers, markerType, options, infobox)
+  {
+    var markerObjs = [];
+    for ( var i = markers.length-1; i >= 0; i-- )
+    {
+      var latLng = new google.maps.LatLng( markers[i][0] , markers[i][1] );
+      var obj = ( markerType == 'native')?
+        angular.extend({ map: map, position: latLng }, options) :
+        angular.extend({ position: latLng }, options);
+      var marker = new google.maps.Marker(obj);
+      // if ( markerType == 'native' )
+      google.maps.event.addListener(
+        marker, 'click', function eventRegister(evt)
+        { infobox.open(map, marker); event.stopPropagation(); event.cancelBubble = true; }
+      );
+      markerObjs[i] = marker;
+    }
+    if ( markerType == 'native' )
+      { return markerObjs; }
+    else if ( markerType == 'cluster' )
+      { return new MarkerClusterer( map, markerObjs, options ); }
+  }
+
+  app.directive('icMapMarkers',
+    ['ic.config', '$parse',
+      function (icConfig, $parse)
+      {
+        function postLink(scope, elm, attrs, controllers)
+        {
+          var _opts = controllers[0].opts.markers;
+          var events = 'animation_changed click clickable_changed ' +
+            'cursor_changed  dblclick drag dragend draggable_changed ' +
+            'dragstart flat_changed icon_changed mousedown mouseout ' +
+            'mouseover mouseup position_changed rightclick shadow_changed ' +
+            'shape_changed title_changed visible_changed zindex_changed';
+
+          scope.$watch(
+            attrs.icMapMarkers,
+            function watchMapMarkers(newMarkerArr)
+            {
+              for(var h = newMarkerArr.length-1; h >= 0; h--)
+              {
+                var options = newMarkerArr[h].options || {};
+                switch(options.status)
+                {
+                  case 4: var color = 'black'; break;
+                  case 3: var color = 'red'; break;
+                  case 2: var color = 'orange'; break;
+                  case 1: var color = 'yellow'; break;
+                  default: var color = 'green';
+                }
+                _opts.icon = _opts.imagesDir + color + '.svg';
+                var natives = addMarkers(
+                  scope.mapObj, [newMarkerArr[h].latLng], 'native', _opts, scope.infoBoxObj
+                );
+                bindMapEvents(scope, events, natives, scope.mapElm);
+              }
+            }
+          );
+        }
+
+        return {
+          restrict: 'A',
+          require: ['?^icMap'],
+          priority: 0,
+          link: postLink
+        };
+      }
+    ]
+  );
+
+  app.directive('icMapClusters',
+    ['$parse',
+      function ($parse)
+      {
+        function postLink(scope, elm, attrs, controllers)
+        {
+          var _opts = controllers[0].opts.clusters;
+          var ngModel = controllers[1];
+          if ( angular.isDefined(attrs.icOptions) )
+            var icOptions = scope.$eval(attrs.icOptions);
+          function createStyles(opts)
+          {
+            for ( var size = opts.styles.length-1; size >= 0; size-- )
+            {
+              opts.styles[size].url = opts.icon = opts.imagesDir + opts.color + '.svg';
+              angular.extend(opts.styles[size], icOptions);
+            }
+          }
+          scope.$watch(
+            attrs.icMapClusters,
+            function watchMapClusters(newClusterArr)
+            {
+              var opts = jQuery.extend(true, {}, _opts);
+              opts.color = icOptions.color;
+              createStyles(opts);
+              var clusters = addMarkers(
+                scope.mapObj, newClusterArr, 'cluster', opts, scope.infoBoxObj
+              );
+              ngModel.$setViewValue(clusters);
+            },
+            true
+          );
+          scope.$watch(
+            attrs.icOptions,
+            function watchIcOptions(newOptions, oldOptions)
+            {
+              if (newOptions !== oldOptions)
+              {
+                if (
+                  angular.isDefined(newOptions.visible)
+                  && angular.isDefined(oldOptions.visible)
+                  && newOptions.visible !== oldOptions.visible
+                  || angular.isDefined(newOptions.visible)
+                )
+                {
+                  var markers = ngModel.$modelValue.markers_;
+                  for ( var i = markers.length-1; i >= 0; i-- )
+                  {
+                    markers[i].setVisible(newOptions.visible);
+                  }
+                  ngModel.$modelValue.repaint();
+                }
+              }//fi
+            },
+            true
+          );
+        }
+        return {
+          restrict: 'A',
+          require: ['?^icMap','?ngModel'],
+          priority: 0,
+          link: postLink
+        };
+      }
+    ]
+  );
+ 
+// Map overlay directives all work the same. Take map marker for example
+// <ui-map-marker="myMarker"> will $watch 'myMarker' and each time it changes,
+// it will hook up myMarker's events to the directive dom element. Then
+// ui-event will be able to catch all of myMarker's events. Super simple.
+  
+  function mapOverlayDirective(directiveName, events)
+  {
     app.directive(directiveName, [function () {
       return {
         restrict: 'A',
-        link: function (scope, elm, attrs) {
-          scope.$watch(attrs[directiveName], function (newObject) {
+        link: function (scope, elm, attrs)
+        {
+          scope.$watch(attrs[directiveName], function (newObject)
+          {
             bindMapEvents(scope, events, newObject, elm);
           });
         }
@@ -99,12 +286,13 @@
     }]);
   }
 
-  mapOverlayDirective('uiMapMarker',
+  /*mapOverlayDirective('uiMapMarker',
     'animation_changed click clickable_changed cursor_changed ' +
-      'dblclick drag dragend draggable_changed dragstart flat_changed icon_changed ' +
-      'mousedown mouseout mouseover mouseup position_changed rightclick ' +
-      'shadow_changed shape_changed title_changed visible_changed zindex_changed');
-
+      'dblclick drag dragend draggable_changed dragstart flat_changed ' +
+      'icon_changed mousedown mouseout mouseover mouseup position_changed ' +
+      'rightclick shadow_changed shape_changed title_changed ' +
+      'visible_changed zindex_changed');*/
+  
   mapOverlayDirective('uiMapPolyline',
     'click dblclick mousedown mousemove mouseout mouseover mouseup rightclick');
 
@@ -123,3 +311,4 @@
     'click dblclick');
 
 })();
+


### PR DESCRIPTION
Hello,

I've created a wrapper for the jQueryUI autocomplete widget (based on uiDate). ~~This does have a known bug where selecting a suggestion via mouseclick does not cause the model to update (but using arrow keys + return does update the model). jQueryUI's autocomplete doesn't have an equivalent `.getDate()` method to get the selected item, so I used `element.val()`, which does not seem to update when the select event is fired from mouseclick.~~ (fixed in 92778051028800958587282b4671982e5b0ac6bd)

This directive supports uiConfig and extends the defaults with a scope object passed from uiAutocomplete.

I saw #414, but the code didn't feel like it came from the AngularUI, and the way it required functions in the controller did not seem to be the "Angular Way" of doing things. Also, I couldn't get it to work.

P.S. Sorry if I've done this pull request incorrectly—I'm new to Github and this is my first PR.
