### PR TITLE
'ui-validate-watch' causes field to be marked dirty immediately

### DIFF
--- a/modules/directives/validate/validate.js
+++ b/modules/directives/validate/validate.js
@@ -46,8 +46,10 @@ angular.module('ui.directives').directive('uiValidate', function () {
 
       // Support for ui-validate-watch
       if (attrs.uiValidateWatch) {
-        scope.$watch(attrs.uiValidateWatch, function() {
-          ctrl.$setViewValue(ctrl.$viewValue);
+        scope.$watch(attrs.uiValidateWatch, function(newVal, oldVal) {
+          if (newVal !== oldVal) {
+            ctrl.$setViewValue(ctrl.$viewValue);
+          }
         });
       }
     }


### PR DESCRIPTION
The fix to #472, while otherwise awesome, causes the marked field to immediately be marked as dirty. This makes styling which relies on `ng-pristine` impossible.
