### PR TITLE
fix uiDateFormat with jQuery.noConflict() enabled

### DIFF
--- a/modules/directives/date/date.js
+++ b/modules/directives/date/date.js
@@ -84,12 +84,12 @@ angular.module('ui.directives')
         // Use the datepicker with the attribute value as the dateFormat string to convert to and from a string
         modelCtrl.$formatters.push(function(value) {
           if (angular.isString(value) ) {
-            return $.datepicker.parseDate(dateFormat, value);
+            return jQuery.datepicker.parseDate(dateFormat, value);
           }
         });
         modelCtrl.$parsers.push(function(value){
           if (value) {
-            return $.datepicker.formatDate(dateFormat, value);
+            return jQuery.datepicker.formatDate(dateFormat, value);
           }
         });
       } else {


### PR DESCRIPTION
Currently, uiDateFormat doesn't work when jQuery.noConflict() is enabled
(because `$.datepicker.formatDate(...);` is used).
Using `jQuery.datepicker.formatDate(...)` fixes that.
