### PR TITLE
Fix initialization for select2 in AJAX mode

### DIFF
--- a/modules/directives/select2/select2.js
+++ b/modules/directives/select2/select2.js
@@ -118,7 +118,11 @@ angular.module('ui.directives').directive('uiSelect2', ['ui.config', '$timeout',
           elm.select2(opts);
 
           // Set initial value - I'm not sure about this but it seems to need to be there
-          elm.val(controller.$viewValue);
+          if (angular.isObject(controller.$viewValue)) {
+            elm.select2('val', controller.$viewValue);
+          } else {
+            elm.select2('data', controller.$viewValue);
+          }
           // important!
           controller.$render();
 


### PR DESCRIPTION
Without this patch initialization gets broken in weird ways. The element value is set to the string "[object Object]" and initSelection is invoked to initialize the model value. If initSelection is not set as an option, the model value is set to null.
