### PR TITLE
Added true to the $watch expression on calendar directive

### DIFF
--- a/modules/directives/calendar/calendar.js
+++ b/modules/directives/calendar/calendar.js
@@ -60,7 +60,7 @@ angular.module('ui.directives').directive('uiCalendar',['ui.config', '$parse', f
               scope.$watch(getSources, function( newVal, oldVal )
               {
                 update();
-              });
+              }, true);
          }
     };
 }]);


### PR DESCRIPTION
This will allow the equalsTracker to detect changes even if the length of the arrays don't change.
