### PR TITLE
Fix issue with uiDateFormat handling of epoch timestamps

### DIFF
--- a/modules/directives/date/date.js
+++ b/modules/directives/date/date.js
@@ -83,7 +83,7 @@ angular.module('ui.directives')
       if ( dateFormat ) {
         // Use the datepicker with the attribute value as the dateFormat string to convert to and from a string
         modelCtrl.$formatters.push(function(value) {
-          if (angular.isString(value) ) {
+          if (angular.isString(value) || (angular.isNumber(value) && dateFormat == '@')) {
             return $.datepicker.parseDate(dateFormat, value);
           }
         });


### PR DESCRIPTION
Condition to check if value `isNumber` and dateFormat is `@`
