### PR TITLE
switching variable name in closure

### DIFF
--- a/common/ieshiv/ieshiv.js
+++ b/common/ieshiv/ieshiv.js
@@ -12,7 +12,7 @@
 //    <script src="build/angular-ui-ieshiv.js"></script>
 // <![endif]-->
 
-(function (exports) {
+(function (window) {
 
   var debug = window.ieShivDebug || false,
       tags = [ "ngInclude", "ngPluralize", "ngView", "ngSwitch", "uiCurrency", "uiCodemirror", "uiDate", "uiEvent",


### PR DESCRIPTION
Hope I did the right thing. 'export' variable wasn't used anywhere in the closure, though window object was.
